### PR TITLE
Fixed window bug

### DIFF
--- a/Main/Source/lsquare.cpp
+++ b/Main/Source/lsquare.cpp
@@ -710,7 +710,7 @@ void lsquare::UpdateMemorizedDescription(truth Cheat)
     {
       MemorizedDescription.Empty();
 
-      if(!OLTerrain || (OLTerrain->IsTransparent() && OLTerrain->ShowThingsUnder()))
+      if(!OLTerrain || (OLTerrain->IsTransparent() && OLTerrain->ShowThingsUnder() && !OLTerrain->IsWall()))
       {
 	truth Anything = false;
 


### PR DESCRIPTION
I couldn't find the root cause of the bug, but I was able to add a check to see if the tile had a window or not. This may cause problems if there are walls that need to be able to see under, but I don't think that is a likely case. Fixes #3 