### PR TITLE
Fixed a bug that could crash the game when reading a scroll of repair

### DIFF
--- a/Main/Include/bodypart.h
+++ b/Main/Include/bodypart.h
@@ -528,6 +528,7 @@ ITEM(corpse, item)
   virtual truth Necromancy(character*);
   virtual int GetSparkleFlags() const;
   virtual truth IsRusted() const { return false; }
+  virtual truth IsBurnt() const { return false; }
   virtual truth CanBeHardened(ccharacter*) const { return false; }
   virtual truth AddBurnLevelDescription(festring&, truth) const { return false; }
   virtual void SignalBurn(material*);


### PR DESCRIPTION
...while carrying a corpse. This is probably not a good final solution since
shouldn't corpses be able to burn? Note that IsRusted is overridden to
return false for corpses too, so it seems corpses can't rust either.

Cause of crash: Without this corpse::IsBurnt override, the game would
call item::IsBurnt which accesses the MainMaterial, however corpses
don't seem to have a MainMaterial (the MainMaterial pointer was 0 when
I debugged this).