### PR TITLE
Make backspace key work on OS X

### DIFF
--- a/FeLib/Include/felibdef.h
+++ b/FeLib/Include/felibdef.h
@@ -141,7 +141,11 @@ inline int GetMinColor24(col24 Color)
 
 #define NORMAL_LUMINANCE 0x808080
 
+#ifndef __APPLE__
 #define KEY_BACK_SPACE 0x08
+#else
+#define KEY_BACK_SPACE 0x7F
+#endif
 #define KEY_ESC 0x1B
 #define KEY_ENTER 0x0D
 #define KEY_UP 0x148


### PR DESCRIPTION
Backspace key didn’t work on OS X, instead it produced the character '€'. One had to enter ctrl-H to type a backspace. Now everything works as it should.