### PR TITLE
Ever have a stacked character die on a shop level?

### DIFF
--- a/Main/Include/game.h
+++ b/Main/Include/game.h
@@ -210,6 +210,7 @@ class game
   static v2 GetDirectionVectorForKey(int);
   static festring SaveName(cfestring& = CONST_S(""));
   static void ShowLevelMessage();
+  static void ShowNoBoneSaveMessage();
   static double GetMinDifficulty();
   static void TriggerQuestForGoldenEagleShirt();
   static void CalculateGodNumber();

--- a/Main/Include/level.h
+++ b/Main/Include/level.h
@@ -167,6 +167,8 @@ class level : public area
   void ParticleTrail(v2, v2);
   festring GetLevelMessage() { return LevelMessage; }
   void SetLevelMessage(cfestring& What) { LevelMessage = What; }
+  festring GetNoBoneSaveMessage() { return NoBoneSaveMessage; }
+  void SetNoBoneSaveMessage(cfestring& What) { NoBoneSaveMessage = What; }
   void SetLevelScript(const levelscript* What) { LevelScript = What; }
   truth IsOnGround() const;
   truth EarthquakesAffectTunnels() const;
@@ -250,6 +252,7 @@ class level : public area
   lsquare*** Map;
   const levelscript* LevelScript;
   festring LevelMessage;
+  festring NoBoneSaveMessage;
   std::vector<v2> Door;
   std::vector<room*> Room;
   int IdealPopulation;

--- a/Main/Include/script.h
+++ b/Main/Include/script.h
@@ -409,6 +409,7 @@ class levelscript : public scriptwithbase
   SCRIPT_MEMBER_WITH_BASE(squarescript, FillSquare);
   SCRIPT_MEMBER_WITH_BASE(squarescript, TunnelSquare);
   SCRIPT_MEMBER_WITH_BASE(festring, LevelMessage);
+  SCRIPT_MEMBER_WITH_BASE(festring, NoBoneSaveMessage);
   SCRIPT_MEMBER_WITH_BASE(v2, Size);
   SCRIPT_MEMBER_WITH_BASE(interval, Items);
   SCRIPT_MEMBER_WITH_BASE(interval, Rooms);

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -1026,6 +1026,14 @@ void game::ShowLevelMessage()
   CurrentLevel->SetLevelMessage("");
 }
 
+void game::ShowNoBoneSaveMessage()
+{
+  if(CurrentLevel->GetNoBoneSaveMessage().GetSize())
+    ADD_MESSAGE(CurrentLevel->GetNoBoneSaveMessage().CStr());
+
+  CurrentLevel->SetNoBoneSaveMessage("");
+}
+
 int game::DirectionQuestion(cfestring& Topic, truth RequireAnswer, truth AcceptYourself)
 {
   for(;;)
@@ -1933,6 +1941,7 @@ void game::EnterArea(charactervector& Group, int Area, int EntryIndex)
     if(New && AutoReveal && *AutoReveal)
       GetCurrentLevel()->Reveal();
 
+    ShowNoBoneSaveMessage();
     ShowLevelMessage();
     SendLOSUpdateRequest();
     UpdateCamera();

--- a/Main/Source/level.cpp
+++ b/Main/Source/level.cpp
@@ -662,7 +662,7 @@ void level::Save(outputfile& SaveFile) const
     for(int y = 0; y < YSize; ++y)
       Map[x][y]->Save(SaveFile);
 
-  SaveFile << Door << LevelMessage << IdealPopulation << MonsterGenerationInterval << Difficulty;
+  SaveFile << Door << LevelMessage << NoBoneSaveMessage << IdealPopulation << MonsterGenerationInterval << Difficulty;
   SaveFile << SunLightEmitation << SunLightDirection << AmbientLuminance << NightAmbientLuminance;
 }
 
@@ -695,7 +695,7 @@ void level::Load(inputfile& SaveFile)
       Map[x][y]->CalculateNeighbourLSquares();
     }
 
-  SaveFile >> Door >> LevelMessage >> IdealPopulation >> MonsterGenerationInterval >> Difficulty;
+  SaveFile >> Door >> LevelMessage >> NoBoneSaveMessage >> IdealPopulation >> MonsterGenerationInterval >> Difficulty;
   SaveFile >> SunLightEmitation >> SunLightDirection >> AmbientLuminance >> NightAmbientLuminance;
   Alloc2D(NodeMap, XSize, YSize);
   Alloc2D(WalkabilityMap, XSize, YSize);
@@ -1777,9 +1777,13 @@ void level::FinalProcessForBone()
 void level::GenerateDungeon(int Index)
 {
   cfestring* Msg = LevelScript->GetLevelMessage();
+  cfestring* BonMsg = LevelScript->GetNoBoneSaveMessage();
 
   if(Msg)
     LevelMessage = *Msg;
+
+  if(BonMsg)
+    NoBoneSaveMessage = *BonMsg;
 
   if(*LevelScript->GenerateMonsters())
   {

--- a/Main/Source/script.cpp
+++ b/Main/Source/script.cpp
@@ -849,6 +849,7 @@ void levelscript::InitDataMap()
   INIT_ENTRY(FillSquare);
   INIT_ENTRY(TunnelSquare);
   INIT_ENTRY(LevelMessage);
+  INIT_ENTRY(NoBoneSaveMessage);
   INIT_ENTRY(Size);
   INIT_ENTRY(Items);
   INIT_ENTRY(Rooms);

--- a/Script/dungeon.dat
+++ b/Script/dungeon.dat
@@ -285,6 +285,7 @@ Dungeon ELPURI_CAVE;
   RandomLevel 1:3;
   {
     CanGenerateBone = false;
+    NoBoneSaveMessage = "It feels less oppressive here. Your spirits rise.";
 
     Room
     {
@@ -370,6 +371,7 @@ Dungeon ELPURI_CAVE;
   RandomLevel 1:4;
   {
     CanGenerateBone = false;
+    NoBoneSaveMessage = "It feels less oppressive here. Your spirits rise.";
 
     Room
     {
@@ -1316,6 +1318,7 @@ Dungeon ATTNAM;
     LOSModifier = 16;
     IgnoreDefaultSpecialSquares = false;
     CanGenerateBone = false;
+    NoBoneSaveMessage = "You worry you might never be found down here, either dead or alive...";
     EnchantmentMinusChanceBase = 0;
     EnchantmentMinusChanceDelta = 0;
     EnchantmentPlusChanceBase = 0;
@@ -3007,6 +3010,7 @@ Dungeon UNDER_WATER_TUNNEL;
     IgnoreDefaultSpecialSquares = true;
     MonsterAmountBase = 5;
     CanGenerateBone = false;
+    NoBoneSaveMessage = "You fear you may never be seen or heard from again.";
 
     RoomDefault
     {


### PR DESCRIPTION
This change enables a message to appear indicating whether or not you are putting your character at risk of never spawning a ghost.
A cryptic sort of message appears, supplementary to the level entry message, hinting that bones are not to be found or left behind on that level. It triggers only once and disappears after.

Messages range from:
UT1: "You fear you may never be seen or heard from again."
Catacombs: "You worry you might never be found down here, either dead or alive..."
GC; Shop or Chest level: "It feels less oppressive here. Your spirits rise."

Attnam, New Attnam and Oree's Lair have no message.