### PR TITLE
More realistic random movement algorithm

### DIFF
--- a/FeLib/Include/felibdef.h
+++ b/FeLib/Include/felibdef.h
@@ -95,6 +95,17 @@ inline void WrapRef(type& Value, type Minimum, type Maximum)
 }
 
 template <class type>
+inline type WrapF(type Value, type Minimum, type Maximum)
+{
+  Value = fmod(Value - Minimum, Maximum - Minimum);
+  return Value >= 0. ? Value + Minimum : Value + Maximum;
+}
+
+template <class type>
+inline void WrapFRef(type& Value, type Minimum, type Maximum)
+{ Value = WrapF(Value, Minimum, Maximum); }
+
+template <class type>
 inline double WrapAverage(type X, type Y, type WrapLimit)
 {
   type Minimum = Min(X, Y);

--- a/FeLib/Include/felibdef.h
+++ b/FeLib/Include/felibdef.h
@@ -48,6 +48,9 @@ culong SquarePartTickMask[4] = { 0xFF, 0xFF00, 0xFF0000, 0xFF000000 };
 #endif
 
 template <class type>
+inline type Sign(type X) { return X > 0 ? 1 : X < 0 ? -1 : 0; }
+
+template <class type>
 inline type Max(type X, type Y) { return X >= Y ? X : Y; }
 
 template <class type>
@@ -75,6 +78,35 @@ inline void LimitRef(type& Value, type Minimum, type Maximum)
     Value = Minimum;
   else if(Value >= Maximum)
     Value = Maximum;
+}
+
+template <class type>
+inline type Wrap(type Value, type Minimum, type Maximum)
+{
+  Value = (Value - Minimum) % (Maximum - Minimum);
+  return (Value >= 0 ? Minimum : Maximum) + Value;
+}
+
+template <class type>
+inline void WrapRef(type& Value, type Minimum, type Maximum)
+{
+  Value = (Value - Minimum) % (Maximum - Minimum);
+  Value += (Value >= 0 ? Minimum : Maximum);
+}
+
+template <class type>
+inline double WrapAverage(type X, type Y, type WrapLimit)
+{
+  type Minimum = Min(X, Y);
+  type Maximum = Max(X, Y);
+
+  if(Maximum - Minimum > WrapLimit / 2)
+  {
+    double Avg = (Minimum + Maximum + WrapLimit) / 2.;
+    return Avg >= WrapLimit ? Avg - WrapLimit : Avg;
+  }
+  else
+    return (X + Y) / 2.;
 }
 
 template <class type>

--- a/FeLib/Include/femath.h
+++ b/FeLib/Include/femath.h
@@ -41,8 +41,9 @@ class femath
   static long Rand();
   static void SetSeed(ulong);
   static long RandN(long N) { return long(double(N) * Rand() / 0x80000000); }
-  static long RandGood(long N)
-  { return long(double(N) * Rand() / 0x80000000); }
+  static long RandGood(long N) { return long(double(N) * Rand() / 0x80000000); }
+  static double RandReal(double N = 1.) { return Rand() * (1. / 0x80000000) * N; }
+  static double NormalDistributedRand(double StandardDeviation = 1.);
   static int WeightedRand(long*, long);
   static int WeightedRand(const std::vector<long>&, long);
   static double CalculateAngle(v2);

--- a/FeLib/Source/femath.cpp
+++ b/FeLib/Source/femath.cpp
@@ -124,6 +124,23 @@ long femath::Rand()
   return y & 0x7FFFFFFF;
 }
 
+double femath::NormalDistributedRand(double StandardDeviation)
+{
+  static double z0, z1;
+  static bool Generate = false;
+
+  if ((Generate = !Generate))
+  {
+    double u1 = sqrt(-2 * log(RandReal()));
+    double u2 = 2 * FPI * RandReal();
+    z0 = u1 * cos(u2);
+    z1 = u1 * sin(u2);
+    return z0 * StandardDeviation;
+  }
+  else
+    return z1 * StandardDeviation;
+}
+
 int femath::WeightedRand(long* Possibility, long TotalPossibility)
 {
   long Rand = RAND() % TotalPossibility, PartialSum = 0;

--- a/Main/Include/char.h
+++ b/Main/Include/char.h
@@ -1168,6 +1168,7 @@ class character : public entity, public id
   int TemporaryStateCounter[STATES];
   team* Team;
   v2 GoingTo;
+  double RandomMoveDir;
   long Money;
   std::list<character*>::iterator TeamIterator;
   bodypartslot* BodyPartSlot;

--- a/Main/Include/game.h
+++ b/Main/Include/game.h
@@ -173,6 +173,7 @@ class game
   static void Run();
   static int GetMoveCommandKey(int);
   static cv2 GetMoveVector(int I) { return MoveVector[I]; }
+  static cv2 GetClockwiseMoveVector(int I) { return ClockwiseMoveVector[I]; }
   static cv2 GetRelativeMoveVector(int I) { return RelativeMoveVector[I]; }
   static cv2 GetBasicMoveVector(int I) { return BasicMoveVector[I]; }
   static cv2 GetLargeMoveVector(int I) { return LargeMoveVector[I]; }
@@ -440,6 +441,7 @@ class game
   static cint MoveAbnormalCommandKey[];
   static cint MoveNetHackCommandKey[];
   static cv2 MoveVector[];
+  static cv2 ClockwiseMoveVector[];
   static cv2 RelativeMoveVector[];
   static cv2 BasicMoveVector[];
   static cv2 LargeMoveVector[];

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -127,6 +127,7 @@ cint game::MoveAbnormalCommandKey[] = { '7','8','9','u','o','j','k','l','.' };
 cint game::MoveNetHackCommandKey[] = { 'y','k','u','h','l','b','j','n','.' };
 
 cv2 game::MoveVector[] = { v2(-1, -1), v2(0, -1), v2(1, -1), v2(-1, 0), v2(1, 0), v2(-1, 1), v2(0, 1), v2(1, 1), v2(0, 0) };
+cv2 game::ClockwiseMoveVector[] = { v2(-1, -1), v2(0, -1), v2(1, -1), v2(1, 0), v2(1, 1), v2(0, 1), v2(-1, 1), v2(-1, 0), v2(0, 0) };
 cv2 game::RelativeMoveVector[] = { v2(-1, -1), v2(1, 0), v2(1, 0), v2(-2, 1), v2(2, 0), v2(-2, 1), v2(1, 0), v2(1, 0), v2(-1, -1) };
 cv2 game::BasicMoveVector[] = { v2(-1, 0), v2(1, 0), v2(0, -1), v2(0, 1) };
 cv2 game::LargeMoveVector[] = { v2(-1, -1), v2(0, -1), v2(1, -1), v2(2, -1), v2(-1, 0), v2(2, 0), v2(-1, 1), v2(2, 1), v2(-1, 2), v2(0, 2), v2(1, 2), v2(2, 2), v2(0, 0), v2(1, 0), v2(0, 1), v2(1, 1) };


### PR DESCRIPTION
Instead of moving to a new random direction each turn, NPCs now "remember" in which direction they're currently moving, and continue moving to that direction until blocked by something. And of course they will pick a new direction every once in a while, even if not blocked.

This affects gameplay somewhat, as monsters patrol the dungeon corridors more "effectively", and will not stay in the same place very long unless trapped.