### PR TITLE
Make some string questions escapable

### DIFF
--- a/Main/Include/game.h
+++ b/Main/Include/game.h
@@ -243,7 +243,7 @@ class game
   static int GetTeams() { return Teams; }
   static void Hostility(team*, team*);
   static void CreateTeams();
-  static festring StringQuestion(cfestring&, col16, festring::sizetype, festring::sizetype, truth, stringkeyhandler = 0);
+  static int StringQuestion(festring&, cfestring&, col16, festring::sizetype, festring::sizetype, truth, stringkeyhandler = 0);
   static long NumberQuestion(cfestring&, int, truth = false);
   static ulong IncreaseLOSTick();
   static ulong GetLOSTick() { return LOSTick; }
@@ -390,8 +390,8 @@ class game
   static int CalculateMinimumEmitationRadius(col24);
   static ulong IncreaseSquarePartEmitationTicks();
   static cint GetLargeMoveDirection(int I) { return LargeMoveDirection[I]; }
-  static void Wish(character*, cchar*, cchar*);
-  static festring DefaultQuestion(festring, festring&, stringkeyhandler = 0);
+  static int Wish(character*, cchar*, cchar*, truth);
+  static int DefaultQuestion(festring&, festring, festring&, truth, stringkeyhandler = 0);
   static void GetTime(ivantime&);
   static long GetTurn() { return Turn; }
   static void IncreaseTurn() { ++Turn; }

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -9024,9 +9024,17 @@ truth character::GetNewFormForPolymorphWithControl(character*& NewForm)
 
   while(!NewForm)
   {
-    festring Temp = game::DefaultQuestion(CONST_S("What do you want to become? [press '?' for a list]"),
-					  game::GetDefaultPolymorphTo(),
-					  &game::PolymorphControlKeyHandler);
+    festring Temp;
+    int Return = game::DefaultQuestion(Temp, CONST_S("What do you want to become? [press '?' for a list]"),
+                                       game::GetDefaultPolymorphTo(), true,
+                                       &game::PolymorphControlKeyHandler);
+    if(Return == ABORTED)
+    {
+      ADD_MESSAGE("You choose not to polymorph.");
+      NewForm = this;
+      return false;
+    }
+    
     NewForm = protosystem::CreateMonster(Temp);
 
     if(NewForm)
@@ -9197,9 +9205,9 @@ void character::TryToName()
   else
   {
     festring Topic = CONST_S("What name will you give to ") + GetName(DEFINITE) + '?';
-    festring Name = game::StringQuestion(Topic, WHITE, 0, 80, true);
+    festring Name;
 
-    if(Name.GetSize())
+    if(game::StringQuestion(Name, Topic, WHITE, 0, 80, true) == NORMAL_EXIT && Name.GetSize())
       SetAssignedName(Name);
   }
 }

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -767,7 +767,11 @@ truth commandsystem::WhatToEngrave(character* Char)
     return false;
   }
 
-  Char->GetNearLSquare(Char->GetPos())->Engrave(game::StringQuestion(CONST_S("What do you want to engrave here?"), WHITE, 0, 80, true));
+  festring What;
+
+  if(game::StringQuestion(What, CONST_S("What do you want to engrave here?"), WHITE, 0, 80, true) == NORMAL_EXIT)
+    Char->GetNearLSquare(Char->GetPos())->Engrave(What);
+
   return false;
 }
 
@@ -1581,8 +1585,11 @@ truth commandsystem::SummonMonster(character* Char)
 
   while(!Summoned)
   {
-    festring Temp = game::DefaultQuestion(CONST_S("Summon which monster?"),
-					  game::GetDefaultSummonMonster());
+    festring Temp;
+
+    if(game::DefaultQuestion(Temp, CONST_S("Summon which monster?"), game::GetDefaultSummonMonster(), true) == ABORTED)
+      return false;
+
     Summoned = protosystem::CreateMonster(Temp);
   }
 

--- a/Main/Source/lterras.cpp
+++ b/Main/Source/lterras.cpp
@@ -387,7 +387,7 @@ truth fountain::Drink(character* Drinker)
 	  ADD_MESSAGE("You have freed a spirit that grants you a wish. You may wish for an item.");
 	  game::Wish(Drinker,
 		     "%s appears from nothing and the spirit flies happily away!",
-		     "Two %s appear from nothing and the spirit flies happily away!");
+		     "Two %s appear from nothing and the spirit flies happily away!", false);
 	}
 	else
 	  DryOut();

--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -110,9 +110,11 @@ void wand::Load(inputfile& SaveFile)
 
 void scrollofwishing::FinishReading(character* Reader)
 {
-  game::Wish(Reader,
-	     "%s appears from nothing and the scroll burns!",
-	     "Two %s appear from nothing and the scroll burns!");
+  while(game::Wish(Reader,
+                   "%s appears from nothing and the scroll burns!",
+                   "Two %s appear from nothing and the scroll burns!", true) == ABORTED)
+    if(game::TruthQuestion(CONST_S("Really cancel read? [y/N]")))
+      return;
 
   RemoveFromSlot();
   SendToHell();
@@ -151,8 +153,15 @@ void scrollofchangematerial::FinishReading(character* Reader)
 	continue;
     }
 
-    festring Temp = game::DefaultQuestion(CONST_S("What material do you want to wish for?"),
-					  game::GetDefaultChangeMaterial());
+    festring Temp;
+
+    if(game::DefaultQuestion(Temp, CONST_S("What material do you want to wish for?"),
+                             game::GetDefaultChangeMaterial(), true) == ABORTED)
+      if(game::TruthQuestion(CONST_S("Really cancel read? [y/N]")))
+        return;
+      else
+        continue;
+
     material* TempMaterial = protosystem::CreateMaterial(Temp);
 
     if(!TempMaterial)
@@ -509,7 +518,7 @@ truth oillamp::Apply(character* Applier)
 	    ADD_MESSAGE("You may wish for an item.");
 	    game::Wish(Applier,
 		       "%s appears from nothing and the genie flies happily away!",
-		       "Two %s appear from nothing and the genie flies happily away!");
+		       "Two %s appear from nothing and the genie flies happily away!", false);
 
 	    Genie->Remove();
 	    delete Genie;
@@ -2500,8 +2509,15 @@ void scrollofdetectmaterial::FinishReading(character* Reader)
 
   for(;;)
   {
-    festring Temp = game::DefaultQuestion(CONST_S("What material do you want to detect?"),
-					  game::GetDefaultDetectMaterial());
+    festring Temp;
+
+    if(game::DefaultQuestion(Temp, CONST_S("What material do you want to detect?"),
+                             game::GetDefaultDetectMaterial(), true) == ABORTED)
+      if(game::TruthQuestion(CONST_S("Really cancel read? [y/N]")))
+        return;
+      else
+        continue;
+
     TempMaterial = protosystem::CreateMaterial(Temp);
 
     if(TempMaterial)


### PR DESCRIPTION
Prompts that are affected:
- Scroll of change material
- Scroll of detect material
- Scroll of wishing
- Polymorph with polycontrol
- Summoning monsters in wizard mode.
- Naming pets
- Engraving

Non-scroll wishes are unaffected.

Resolves #48.