### PR TITLE
Make BLUE lighter

### DIFF
--- a/FeLib/Include/felibdef.h
+++ b/FeLib/Include/felibdef.h
@@ -172,7 +172,7 @@ inline int GetMinColor24(col24 Color)
 
 #define RED 0xF800
 #define GREEN 0x07E0
-#define BLUE 0x001F
+#define BLUE 0x2ABF
 
 #define YELLOW 0xFFE0
 #define PINK 0xF01E

--- a/Script/define.dat
+++ b/Script/define.dat
@@ -28,7 +28,7 @@
 
 #define RED 63488
 #define GREEN 2016
-#define BLUE 31
+#define BLUE 10943
 
 #define YELLOW 65504
 #define PINK 61470


### PR DESCRIPTION
Makes blue status strings more readable and thus fixes #53.

This also affects some other things such as the blue outline color of mystic frogs and the smell staff, which was a bit too dark anyway (compared to the other colors).