### PR TITLE
Fix missing articles

### DIFF
--- a/Main/Source/item.cpp
+++ b/Main/Source/item.cpp
@@ -1927,10 +1927,10 @@ void item::SendMemorizedUpdateRequest() const
 
 truth item::AddStateDescription(festring& Name, truth Articled) const
 {
-  if(!Spoils())
+  if(!Spoils() || !(ItemFlags & (HASTE|SLOW)))
     return false;
 
-  if((ItemFlags & (HASTE|SLOW)) && Articled)
+  if(Articled)
     Name << "a ";
 
   if(ItemFlags & HASTE)


### PR DESCRIPTION
This was caused by AddStateDescription not returning false when it should have, i.e.
when it wasn't going to add "hasted" or "slowed" to the item name.

Fixes #20.