### PR TITLE
Revert "Fixed typo in Atavus XMas message"

### DIFF
--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -385,7 +385,7 @@ truth game::Init(cfestring& Name)
       {
 	item* Present = banana::Spawn();
 	Player->GetStack()->AddItem(Present);
-	ADD_MESSAGE("Atavus is happy today! He gives you a %s.", Present->CHAR_NAME(INDEFINITE));
+	ADD_MESSAGE("Atavus is happy today! He gives you %s.", Present->CHAR_NAME(INDEFINITE));
       }
 
       return true;


### PR DESCRIPTION
This reverts commit 15fce3ef20b849c5126327bf143655e738e76560.

The "typo" was actually a bug that affected other indefinite articles as well (see #20). #60 makes the indefinite articles work again, so this would print "a a banana". This commit fixes that.
