### PR TITLE
This change causes a test at each transition in burn level, where the…

### DIFF
--- a/Main/Source/materias.cpp
+++ b/Main/Source/materias.cpp
@@ -61,7 +61,17 @@ void solid::Be(ulong Flags)
 
           if(NewBurnLevel != GetBurnLevel())
           {
+            truth NaturallyExtinguish = false;
+            if(((RAND() % 4) - GetBurnLevel()) <= 0)
+              NaturallyExtinguish = true;
+
             SetBurnLevel(GetBurnLevel() + 1, true);
+
+            if(NaturallyExtinguish)
+            {
+              MotherEntity->Extinguish(true);
+              ResetThermalEnergies();
+            }
           }
         }
       }


### PR DESCRIPTION
… probability that the flames will be extinguished at each transition is governed according to https://attnam.com/posts/25678 which is implemented as follows:

```
if(((RAND() % 4) - GetBurnLevel()) <= 0)
  NaturallyExtinguish = true;
```

Heavily burnt items that are on fire should undergo complete combustion