### PR TITLE
C++11 migration, part 1

### DIFF
--- a/FeLib/Include/bitmap.h
+++ b/FeLib/Include/bitmap.h
@@ -26,9 +26,9 @@ typedef void (*bitmapeditor)(bitmap*, truth);
 struct blitdata
 {
   bitmap* Bitmap;
-  podv2 Src;
-  podv2 Dest;
-  podv2 Border;
+  v2 Src;
+  v2 Dest;
+  v2 Border;
   union
   {
     int Flags, Stretch;

--- a/FeLib/Include/config.h
+++ b/FeLib/Include/config.h
@@ -58,7 +58,7 @@ class configsystem
 struct configoption
 {
   configoption(cchar*, cchar*);
-  virtual ~configoption() { }
+  virtual ~configoption() = default;
   virtual void SaveValue(std::ofstream&) const = 0;
   virtual void LoadValue(inputfile&) = 0;
   virtual truth ActivateChangeInterface() = 0;

--- a/FeLib/Include/error.h
+++ b/FeLib/Include/error.h
@@ -26,7 +26,7 @@ class globalerrorhandler
  public:
   static void Install();
   static void DeInstall();
-  static void NO_RETURN LIKE_PRINTF(1, 2) Abort(cchar*, ...);
+  [[noreturn]] static void LIKE_PRINTF(1, 2) Abort(cchar*, ...);
   static cchar* GetBugMsg() { return BugMsg; }
  private:
   static cchar* BugMsg;

--- a/FeLib/Include/felibdef.h
+++ b/FeLib/Include/felibdef.h
@@ -39,11 +39,9 @@ culong SquarePartTickMask[4] = { 0xFF, 0xFF00, 0xFF0000, 0xFF000000 };
 
 #ifdef GCC
 #define NO_ALIGNMENT __attribute__ ((packed))
-#define NO_RETURN __attribute__ ((noreturn))
 #define LIKE_PRINTF(p1, p2) __attribute__ ((format(printf, p1, p2)))
 #else
 #define NO_ALIGNMENT
-#define NO_RETURN
 #define LIKE_PRINTF(p1, p2)
 #endif
 

--- a/FeLib/Include/femath.h
+++ b/FeLib/Include/femath.h
@@ -285,7 +285,7 @@ inline void mapmath<controller>::DoQuadriArea(int OrigoX, int OrigoY,
     controller::Handler((OrigoX << 1) + basequadricontroller::OrigoDeltaX[c],
 			(OrigoY << 1) + basequadricontroller::OrigoDeltaY[c]);
 
-  mapmath<quadricontroller<controller> >::DoArea();
+  mapmath<quadricontroller<controller>>::DoArea();
 }
 
 /* Chance for n < Max to be returned is (1-CC)*CC^n,

--- a/FeLib/Include/festring.h
+++ b/FeLib/Include/festring.h
@@ -30,8 +30,7 @@ class festring
   festring() : Data(0), Size(0), OwnsData(false) { }
   explicit festring(sizetype);
   festring(sizetype, char);
-  festring(cchar* CStr)
-  : Data(const_cast<char*>(CStr)), Size(strlen(CStr)), OwnsData(false) { }
+  festring(cchar* CStr) : festring(CStr, strlen(CStr)) { }
   festring(cchar* CStr, sizetype N)
   : Data(const_cast<char*>(CStr)), Size(N), OwnsData(false) { }
   festring(cfestring&);
@@ -154,12 +153,9 @@ inline festring::festring(sizetype N)
 }
 
 inline festring::festring(sizetype N, char C)
-: Size(N), OwnsData(true), Reserved(N|FESTRING_PAGE)
+: festring(N)
 {
-  char* Ptr = sizeof(int*) + new char[Reserved + sizeof(int*)+1];
-  REFS(Ptr) = 0;
-  Data = Ptr;
-  memset(Ptr, C, N);
+  memset(Data, C, N);
 }
 
 inline festring::~festring()

--- a/FeLib/Include/rawbit.h
+++ b/FeLib/Include/rawbit.h
@@ -24,7 +24,7 @@ class bitmap;
 class cachedfont;
 class festring;
 
-typedef std::map<col16, std::pair<cachedfont*, cachedfont*> > fontcache;
+typedef std::map<col16, std::pair<cachedfont*, cachedfont*>> fontcache;
 
 class rawbitmap
 {

--- a/FeLib/Include/rect.h
+++ b/FeLib/Include/rect.h
@@ -17,7 +17,7 @@
 
 struct rect
 {
-  rect() { }
+  rect() = default;
   rect(int X1, int Y1, int X2, int Y2) : X1(X1), Y1(Y1), X2(X2), Y2(Y2) { }
   rect(v2 V1, v2 V2) : X1(V1.X), Y1(V1.Y), X2(V2.X), Y2(V2.Y) { }
   rect operator+(v2 V) const

--- a/FeLib/Include/save.h
+++ b/FeLib/Include/save.h
@@ -294,9 +294,8 @@ inline outputfile& operator<<(outputfile& SaveFile,
 {
   SaveFile << ulong(List.size());
 
-  for(typename std::list<type>::const_iterator i = List.begin();
-      i != List.end(); ++i)
-    SaveFile << *i;
+  for(const type& Element : List)
+    SaveFile << Element;
 
   return SaveFile;
 }
@@ -307,9 +306,8 @@ inline inputfile& operator>>(inputfile& SaveFile,
 {
   List.resize(ReadType<ulong>(SaveFile), type());
 
-  for(typename std::list<type>::iterator i = List.begin();
-      i != List.end(); ++i)
-    SaveFile >> *i;
+  for(type& Element : List)
+    SaveFile >> Element;
 
   return SaveFile;
 }
@@ -320,9 +318,8 @@ inline outputfile& operator<<(outputfile& SaveFile,
 {
   SaveFile << ulong(Map.size());
 
-  for(typename std::map<type1, type2>::const_iterator i = Map.begin();
-      i != Map.end(); ++i)
-    SaveFile << i->first << i->second;
+  for(const typename std::map<type1, type2>::value_type& Pair : Map)
+    SaveFile << Pair.first << Pair.second;
 
   return SaveFile;
 }
@@ -353,9 +350,8 @@ inline outputfile& operator<<(outputfile& SaveFile,
 {
   SaveFile << ulong(Set.size());
 
-  for(typename std::set<type>::const_iterator i = Set.begin();
-      i != Set.end(); ++i)
-    SaveFile << *i;
+  for(const typename std::set<type>::value_type& Element : Set)
+    SaveFile << Element;
 
   return SaveFile;
 }

--- a/FeLib/Include/save.h
+++ b/FeLib/Include/save.h
@@ -101,6 +101,8 @@ template <class type> inline type ReadType(inputfile& SaveFile)
   return Variable;
 }
 
+inline void ReadData(truth& Type, inputfile& SaveFile)
+{ Type = SaveFile.ReadNumber(); }
 inline void ReadData(char& Type, inputfile& SaveFile)
 { Type = SaveFile.ReadNumber(); }
 inline void ReadData(uchar& Type, inputfile& SaveFile)
@@ -156,6 +158,18 @@ inline void ReadData(fearray<type>& Array, inputfile& SaveFile)
   if(SaveFile.ReadWord() != "}")
     ABORT("Illegal array terminator \"%s\" encountered in file %s, line %ld!",
 	  Word.CStr(), SaveFile.GetFileName().CStr(), SaveFile.TellLine());
+}
+
+inline outputfile& operator<<(outputfile& SaveFile, truth Value)
+{
+  SaveFile.Put(Value);
+  return SaveFile;
+}
+
+inline inputfile& operator>>(inputfile& SaveFile, truth& Value)
+{
+  Value = SaveFile.Get();
+  return SaveFile;
 }
 
 inline outputfile& operator<<(outputfile& SaveFile, char Value)

--- a/FeLib/Include/typedef.h
+++ b/FeLib/Include/typedef.h
@@ -20,7 +20,7 @@ class festring;
 struct blitdata;
 struct v2;
 
-typedef long truth;
+typedef bool truth;
 typedef unsigned char uchar;
 typedef unsigned short ushort;
 typedef unsigned int uint;
@@ -34,9 +34,9 @@ typedef int priority;
 typedef uchar packpriority;
 typedef uchar paletteindex;
 
+typedef const bool ctruth;
 typedef const char cchar;
 typedef const int cint;
-typedef const long ctruth;
 typedef const unsigned char cuchar;
 typedef const unsigned short cushort;
 typedef const unsigned int cuint;

--- a/FeLib/Include/v2.h
+++ b/FeLib/Include/v2.h
@@ -25,17 +25,11 @@ struct packv2
   short X, Y;
 };
 
-struct podv2
-{
-  operator v2() const;
-  int X, Y;
-};
-
 /* Standard structure for representing positions */
 
 struct v2
 {
-  v2() { }
+  v2() = default;
   v2(int X, int Y) : X(X), Y(Y) { }
   v2 operator+(v2 V) const { return v2(X + V.X, Y + V.Y); }
   v2& operator+=(v2 V) { X += V.X; Y += V.Y; return *this; }
@@ -73,18 +67,12 @@ struct v2
     packv2 V = { static_cast<short>(X), static_cast<short>(Y) };
     return V;
   }
-  operator podv2() const
-  {
-    podv2 V = { X, Y };
-    return V;
-  }
 
   //  v2 Randomize() const; Would be a good idea.
   int X, Y;
 };
 
 inline packv2::operator v2() const { return v2(X, Y); }
-inline podv2::operator v2() const { return v2(X, Y); }
 
 /*
  * Rotates a position Vect of a square map of size

--- a/FeLib/Source/bitmap.cpp
+++ b/FeLib/Source/bitmap.cpp
@@ -163,11 +163,8 @@ bitmap::bitmap(cfestring& FileName)
 }
 
 bitmap::bitmap(cbitmap* Bitmap, int Flags, truth CopyAlpha)
-: Size(Bitmap->Size), XSizeTimesYSize(Bitmap->XSizeTimesYSize),
-  FastFlag(0), PriorityMap(0), RandMap(0)
+: bitmap(Bitmap->Size)
 {
-  Alloc2D(Image, Size.Y, Size.X);
-
   if(CopyAlpha && Bitmap->AlphaMap)
   {
     Alloc2D(AlphaMap, Size.Y, Size.X);
@@ -175,8 +172,6 @@ bitmap::bitmap(cbitmap* Bitmap, int Flags, truth CopyAlpha)
   }
   else
   {
-    AlphaMap = 0;
-
     if(!Flags)
       Bitmap->FastBlit(this);
     else
@@ -192,10 +187,8 @@ bitmap::bitmap(v2 Size)
 }
 
 bitmap::bitmap(v2 Size, col16 Color)
-: Size(Size), XSizeTimesYSize(Size.X * Size.Y),
-  FastFlag(0), AlphaMap(0), PriorityMap(0), RandMap(0)
+: bitmap(Size)
 {
-  Alloc2D(Image, Size.Y, Size.X);
   ClearToColor(Color);
 }
 

--- a/FeLib/Source/felist.cpp
+++ b/FeLib/Source/felist.cpp
@@ -63,7 +63,7 @@ inputfile& operator>>(inputfile& SaveFile, felistentry*& Entry)
 
 struct felistdescription
 {
-  felistdescription() { }
+  felistdescription() = default;
   felistdescription(cfestring& String, col16 Color)
   : String(String), Color(Color) { }
   festring String;

--- a/FeLib/Source/rawbit.cpp
+++ b/FeLib/Source/rawbit.cpp
@@ -67,10 +67,10 @@ rawbitmap::~rawbitmap()
   delete [] Palette;
   delete [] PaletteBuffer;
 
-  for(fontcache::iterator i = FontCache.begin(); i != FontCache.end(); ++i)
+  for(fontcache::value_type& p : FontCache)
   {
-    delete i->second.first;
-    delete i->second.second;
+    delete p.second.first;
+    delete p.second.second;
   }
 }
 

--- a/Main/Include/action.h
+++ b/Main/Include/action.h
@@ -41,7 +41,7 @@ class action
  public:
   typedef actionprototype prototype;
   action()  : Actor(0), Flags(0) { }
-  virtual ~action() { }
+  virtual ~action() = default;
   virtual void Handle() = 0;
   virtual void Terminate(truth);
   character* GetActor() const { return Actor; }

--- a/Main/Include/area.h
+++ b/Main/Include/area.h
@@ -26,7 +26,7 @@ class inputfile;
 class area
 {
  public:
-  area();
+  area() = default;
   area(int, int);
   virtual ~area();
   virtual void Draw(truth) const = 0;

--- a/Main/Include/bodypart.h
+++ b/Main/Include/bodypart.h
@@ -494,7 +494,7 @@ ITEM(leftleg, leg)
 ITEM(corpse, item)
 {
  public:
-  corpse() { }
+  corpse() = default;
   corpse(const corpse&);
   virtual ~corpse();
   virtual int GetOfferValue(int) const;
@@ -597,7 +597,7 @@ ITEM(ennerhead, head)
 ITEM(playerkindhead, head)
 {
  public:
-  playerkindhead() { }
+  playerkindhead() = default;
   playerkindhead(const playerkindhead& Head) : mybase(Head) { }
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
@@ -612,7 +612,7 @@ ITEM(playerkindhead, head)
 ITEM(playerkindtorso, humanoidtorso)
 {
  public:
-  playerkindtorso() { }
+  playerkindtorso() = default;
   playerkindtorso(const playerkindtorso& Torso) : mybase(Torso) { }
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
@@ -630,7 +630,7 @@ ITEM(playerkindtorso, humanoidtorso)
 ITEM(playerkindrightarm, rightarm)
 {
  public:
-  playerkindrightarm() { }
+  playerkindrightarm() = default;
   playerkindrightarm(const playerkindrightarm& Arm) : mybase(Arm) { }
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
@@ -646,7 +646,7 @@ ITEM(playerkindrightarm, rightarm)
 ITEM(playerkindleftarm, leftarm)
 {
  public:
-  playerkindleftarm() { }
+  playerkindleftarm() = default;
   playerkindleftarm(const playerkindleftarm& Arm) : mybase(Arm) { }
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
@@ -662,7 +662,7 @@ ITEM(playerkindleftarm, leftarm)
 ITEM(playerkindgroin, groin)
 {
  public:
-  playerkindgroin() { }
+  playerkindgroin() = default;
   playerkindgroin(const playerkindgroin& Groin) : mybase(Groin) { }
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
@@ -677,7 +677,7 @@ ITEM(playerkindgroin, groin)
 ITEM(playerkindrightleg, rightleg)
 {
  public:
-  playerkindrightleg() { }
+  playerkindrightleg() = default;
   playerkindrightleg(const playerkindrightleg& Leg) : mybase(Leg) { }
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
@@ -693,7 +693,7 @@ ITEM(playerkindrightleg, rightleg)
 ITEM(playerkindleftleg, leftleg)
 {
  public:
-  playerkindleftleg() { }
+  playerkindleftleg() = default;
   playerkindleftleg(const playerkindleftleg& Leg) : mybase(Leg) { }
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);

--- a/Main/Include/char.h
+++ b/Main/Include/char.h
@@ -38,7 +38,7 @@ struct homedata;
 struct trapdata;
 struct blitdata;
 
-typedef std::vector<std::pair<double, int> > blockvector;
+typedef std::vector<std::pair<double, int>> blockvector;
 typedef truth (item::*sorter)(ccharacter*) const;
 typedef truth (character::*petmanagementfunction)();
 typedef character* (*characterspawner)(int, int);
@@ -198,7 +198,7 @@ struct characterdatabase : public databasebase
   int RightSWeaponSkillHits;
   int LeftSWeaponSkillHits;
   int PanicLevel;
-  fearray<contentscript<item> > Inventory;
+  fearray<contentscript<item>> Inventory;
   int DangerModifier;
   festring DefaultName;
   fearray<festring> FriendlyReplies;
@@ -790,7 +790,7 @@ class character : public entity, public id
   void AddAntidoteConsumeEndMessage() const;
   truth IsDead() const;
   void AddOriginalBodyPartID(int, ulong);
-  void AddToInventory(const fearray<contentscript<item> >&, int);
+  void AddToInventory(const fearray<contentscript<item>>&, int);
   truth HasHadBodyPart(citem*) const;
   void ProcessAndAddMessage(festring) const;
   virtual truth CheckZap();

--- a/Main/Include/cont.h
+++ b/Main/Include/cont.h
@@ -25,7 +25,7 @@ class continent
 {
  public:
   friend class worldmap;
-  continent();
+  continent() = default;
   continent(int);
   void AttachTo(continent*);
   void Add(v2);

--- a/Main/Include/dungeon.h
+++ b/Main/Include/dungeon.h
@@ -25,7 +25,7 @@ class festring;
 class dungeon
 {
  public:
-  dungeon();
+  dungeon() = default;
   dungeon(int);
   ~dungeon();
   truth PrepareLevel(int, truth = true);

--- a/Main/Include/game.h
+++ b/Main/Include/game.h
@@ -73,7 +73,7 @@ inputfile& operator>>(inputfile&, homedata*&);
 
 struct configid
 {
-  configid() { }
+  configid() = default;
   configid(int Type, int Config) : Type(Type), Config(Config) { }
   bool operator<(const configid& CI) const { return memcmp(this, &CI, sizeof(configid)) < 0; }
   int Type NO_ALIGNMENT;
@@ -89,7 +89,7 @@ inputfile& operator>>(inputfile&, configid&);
 
 struct dangerid
 {
-  dangerid() { }
+  dangerid() = default;
   dangerid(double NakedDanger, double EquippedDanger) : NakedDanger(NakedDanger), EquippedDanger(EquippedDanger) { }
   double NakedDanger;
   double EquippedDanger;
@@ -107,7 +107,7 @@ struct ivantime
 
 struct massacreid
 {
-  massacreid() { }
+  massacreid() = default;
   massacreid(int Type, int Config, cfestring& Name)
   : Type(Type), Config(Config), Name(Name) { }
   bool operator<(const massacreid&) const;
@@ -132,7 +132,7 @@ inputfile& operator>>(inputfile&, massacreid&);
 
 struct killreason
 {
-  killreason() { }
+  killreason() = default;
   killreason(cfestring& String, int Amount) : String(String), Amount(Amount) { }
   festring String;
   int Amount;

--- a/Main/Include/gear.h
+++ b/Main/Include/gear.h
@@ -18,7 +18,7 @@
 ITEM(meleeweapon, item)
 {
  public:
-  meleeweapon() { }
+  meleeweapon() = default; 
   meleeweapon(const meleeweapon&);
   virtual ~meleeweapon();
   virtual truth HitEffect(character*, character*, v2, int, int, truth);

--- a/Main/Include/igraph.h
+++ b/Main/Include/igraph.h
@@ -32,7 +32,7 @@ class festring;
 
 struct graphicid
 {
-  graphicid() { }
+  graphicid() = default;
   bool operator<(const graphicid&) const;
   ushort BitmapPosX NO_ALIGNMENT;
   ushort BitmapPosY NO_ALIGNMENT;
@@ -69,7 +69,7 @@ inputfile& operator>>(inputfile&, graphicid&);
 
 struct tile
 {
-  tile() { }
+  tile() = default;
   tile(bitmap* Bitmap) : Bitmap(Bitmap), Users(1) { }
   bitmap* Bitmap;
   long Users;

--- a/Main/Include/item.h
+++ b/Main/Include/item.h
@@ -479,7 +479,7 @@ class item : public object
   void ResetSpoiling();
   void ResetBurning();
   void ResetThermalEnergies();
-  virtual void SetItemsInside(const fearray<contentscript<item> >&, int) { }
+  virtual void SetItemsInside(const fearray<contentscript<item>>&, int) { }
   virtual int GetCarryingBonus() const { return 0; }
   virtual truth IsBanana() const { return false; }
   virtual truth IsEncryptedScroll() const { return false; }

--- a/Main/Include/lsquare.h
+++ b/Main/Include/lsquare.h
@@ -41,7 +41,7 @@ typedef truth (item::*sorter)(ccharacter*) const;
 struct emitter
 {
   emitter(ulong ID, col24 Emitation) : ID(ID), Emitation(Emitation) { }
-  explicit emitter() { }
+  explicit emitter() = default;
   ulong ID;
   col24 Emitation;
 };

--- a/Main/Include/lterra.h
+++ b/Main/Include/lterra.h
@@ -211,7 +211,7 @@ struct olterraindatabase : public lterraindatabase
   int HPModifier;
   v2 OpenBitmapPos;
   v2 WindowBitmapPos;
-  fearray<contentscript<item> > LeftOverItems;
+  fearray<contentscript<item>> LeftOverItems;
   truth CreateDivineConfigurations;
   truth CanBeDestroyed;
   truth IsUpLink;
@@ -307,13 +307,13 @@ class olterrain : public lterrain, public oterrain
   DATA_BASE_TRUTH(IsAlwaysTransparent);
   DATA_BASE_TRUTH(CreateWindowConfigurations);
   DATA_BASE_VALUE(v2, WindowBitmapPos);
-  DATA_BASE_VALUE(const fearray<contentscript<item> >&, LeftOverItems);
+  DATA_BASE_VALUE(const fearray<contentscript<item>>&, LeftOverItems);
   DATA_BASE_TRUTH(IsWall);
   virtual void SetAttachedArea(int) { }
   virtual void SetAttachedEntry(int) { }
   virtual void SetText(cfestring&) { }
   virtual festring GetText() const;
-  virtual void SetItemsInside(const fearray<contentscript<item> >&, int) { }
+  virtual void SetItemsInside(const fearray<contentscript<item>>&, int) { }
   int GetStrengthValue() const;
   virtual void SignalVolumeAndWeightChange() { HP = CalculateMaxHP(); }
   int CalculateMaxHP();

--- a/Main/Include/lterras.h
+++ b/Main/Include/lterras.h
@@ -124,7 +124,7 @@ OLTERRAIN(olterraincontainer, olterrain)
   virtual stack* GetContained() const { return Contained; }
   virtual void Load(inputfile&);
   virtual void Save(outputfile&) const;
-  virtual void SetItemsInside(const fearray<contentscript<item> >&, int);
+  virtual void SetItemsInside(const fearray<contentscript<item>>&, int);
   virtual void Break();
   virtual truth AllowContentEmitation() const { return false; }
   virtual void PreProcessForBone();

--- a/Main/Include/materia.h
+++ b/Main/Include/materia.h
@@ -103,7 +103,7 @@ class material
   typedef materialdatabase database;
   material(int NewConfig, long InitVolume = 0, truth Load = false) : MotherEntity(0) { Initialize(NewConfig, InitVolume, Load); }
   material() : MotherEntity(0) { }
-  virtual ~material() { }
+  virtual ~material() = default; 
   void AddName(festring&, truth = false, truth = true) const;
   festring GetName(truth = false, truth = true) const;
   material* TakeDipVolumeAway();

--- a/Main/Include/miscitem.h
+++ b/Main/Include/miscitem.h
@@ -414,7 +414,7 @@ ITEM(itemcontainer, lockableitem)
   virtual void DrawContents(ccharacter*);
   virtual truth Apply(character* Applier) { return Open(Applier); }
   virtual truth IsAppliable(ccharacter*) const { return true; }
-  virtual void SetItemsInside(const fearray<contentscript<item> >&, int);
+  virtual void SetItemsInside(const fearray<contentscript<item>>&, int);
   virtual truth AllowContentEmitation() const { return false; }
   virtual truth IsDestroyable(ccharacter*) const;
   virtual int GetOfferValue(int) const;

--- a/Main/Include/miscitem.h
+++ b/Main/Include/miscitem.h
@@ -20,7 +20,7 @@
 ITEM(materialcontainer, item)
 {
  public:
-  materialcontainer() { }
+  materialcontainer() = default;
   materialcontainer(const materialcontainer&);
   virtual ~materialcontainer();
   virtual material* GetSecondaryMaterial() const { return SecondaryMaterial; }

--- a/Main/Include/room.h
+++ b/Main/Include/room.h
@@ -45,7 +45,7 @@ class room
  public:
   typedef roomprototype prototype;
   room() : LastMasterSearchTick(0), MasterID(0) { }
-  virtual ~room() { }
+  virtual ~room() = default; 
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
   virtual void Enter(character*) { }

--- a/Main/Include/script.h
+++ b/Main/Include/script.h
@@ -67,7 +67,7 @@ class inputfile;
 
 struct scriptmemberbase
 {
-  virtual ~scriptmemberbase() { }
+  virtual ~scriptmemberbase() = default;
   virtual void ReadFrom(inputfile&) = 0;
   virtual void Save(outputfile&) const = 0;
   virtual void Load(inputfile&) = 0;
@@ -112,7 +112,7 @@ template <class type> inline scriptmember<type>& scriptmember<type>::operator=(c
 
 template <class type> struct fastscriptmember : public scriptmemberbase
 {
-  fastscriptmember() { }
+  fastscriptmember() = default;
   fastscriptmember(type Member) : Member(Member) { }
   virtual void ReadFrom(inputfile&);
   virtual void Replace(scriptmemberbase&);
@@ -125,7 +125,7 @@ class script
 {
  public:
   typedef std::map<cchar*, scriptmemberbase script::*, charcomparer> datamap;
-  virtual ~script() { }
+  virtual ~script() = default;
   virtual void ReadFrom(inputfile&) = 0;
   virtual void Save(outputfile& SaveFile) const { SaveDataMap(GetDataMap(), SaveFile); }
   virtual void Load(inputfile& SaveFile) { LoadDataMap(GetDataMap(), SaveFile); }
@@ -445,8 +445,8 @@ class dungeonscript : public script
 {
  public:
   typedef dungeonscript scripttype;
-  dungeonscript();
-  virtual ~dungeonscript();
+  dungeonscript() = default;
+  virtual ~dungeonscript() = default;
   virtual void ReadFrom(inputfile&);
   const std::map<int, levelscript>& GetLevel() const;
   void RandomizeLevels();

--- a/Main/Include/script.h
+++ b/Main/Include/script.h
@@ -237,7 +237,7 @@ class contentscript<item> : public contentscripttemplate<item>
   virtual const datamap& GetDataMap() const { return DataMap; }
   virtual cchar* GetClassID() const;
   static datamap DataMap;
-  SCRIPT_MEMBER(fearray<contentscript<item> >, ItemsInside);
+  SCRIPT_MEMBER(fearray<contentscript<item>>, ItemsInside);
   SCRIPT_MEMBER(interval, Times);
   SCRIPT_MEMBER(interval, LifeExpectancy);
   FAST_SCRIPT_MEMBER(ulong, Category);
@@ -252,7 +252,7 @@ class contentscript<item> : public contentscripttemplate<item>
   FAST_SCRIPT_TRUTH(IsActive);
 };
 
-truth IsValidScript(const fearray<contentscript<item> >*);
+truth IsValidScript(const fearray<contentscript<item>>*);
 
 template <>
 class contentscript<character> : public contentscripttemplate<character>
@@ -266,7 +266,7 @@ class contentscript<character> : public contentscripttemplate<character>
   virtual const datamap& GetDataMap() const { return DataMap; }
   virtual cchar* GetClassID() const;
   static datamap DataMap;
-  SCRIPT_MEMBER(fearray<contentscript<item> >, Inventory);
+  SCRIPT_MEMBER(fearray<contentscript<item>>, Inventory);
   SCRIPT_MEMBER(fearray<packv2>, WayPoint);
   FAST_SCRIPT_MEMBER(uchar, Team);
   FAST_SCRIPT_MEMBER(uchar, Flags);
@@ -298,7 +298,7 @@ class contentscript<olterrain> : public contentscripttemplate<olterrain>
   virtual const datamap& GetDataMap() const { return DataMap; }
   static datamap DataMap;
   virtual cchar* GetClassID() const;
-  SCRIPT_MEMBER(fearray<contentscript<item> >, ItemsInside);
+  SCRIPT_MEMBER(fearray<contentscript<item>>, ItemsInside);
   SCRIPT_MEMBER(festring, Text);
   FAST_SCRIPT_MEMBER(uchar, VisualEffects);
   FAST_SCRIPT_MEMBER(uchar, AttachedArea);
@@ -317,7 +317,7 @@ class squarescript : public script
   static datamap DataMap;
   SCRIPT_MEMBER(posscript, Position);
   SCRIPT_MEMBER(contentscript<character>, Character);
-  SCRIPT_MEMBER(fearray<contentscript<item> >, Items);
+  SCRIPT_MEMBER(fearray<contentscript<item>>, Items);
   SCRIPT_MEMBER(contentscript<glterrain>, GTerrain);
   SCRIPT_MEMBER(contentscript<olterrain>, OTerrain);
   SCRIPT_MEMBER(interval, Times);
@@ -325,7 +325,7 @@ class squarescript : public script
   FAST_SCRIPT_TRUTH(AttachRequired);
 };
 
-template <class type, class contenttype = contentscript<type> > class contentmap : public script
+template <class type, class contenttype = contentscript<type>> class contentmap : public script
 {
  public:
   typedef contentmap scripttype;
@@ -345,7 +345,7 @@ template <class type, class contenttype = contentscript<type> > class contentmap
   SCRIPT_MEMBER(v2, Pos);
 };
 
-typedef contentmap<item, fearray<contentscript<item> > > itemcontentmap;
+typedef contentmap<item, fearray<contentscript<item>>> itemcontentmap;
 typedef contentmap<character> charactercontentmap;
 typedef contentmap<glterrain> glterraincontentmap;
 typedef contentmap<olterrain> olterraincontentmap;
@@ -457,7 +457,7 @@ class dungeonscript : public script
  protected:
   static datamap DataMap;
   std::map<int, levelscript> Level;
-  std::list<std::pair<interval, levelscript> > RandomLevel;
+  std::list<std::pair<interval, levelscript>> RandomLevel;
   SCRIPT_MEMBER(levelscript, LevelDefault);
   SCRIPT_MEMBER(int, Levels);
   SCRIPT_MEMBER(festring, Description);
@@ -469,14 +469,14 @@ class teamscript : public script
  public:
   typedef teamscript scripttype;
   virtual void ReadFrom(inputfile&);
-  const std::vector<std::pair<int, int> >& GetRelation() const;
+  const std::vector<std::pair<int, int>>& GetRelation() const;
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
   static void InitDataMap();
  protected:
   virtual const datamap& GetDataMap() const { return DataMap; }
   static datamap DataMap;
-  std::vector<std::pair<int, int> > Relation;
+  std::vector<std::pair<int, int>> Relation;
   SCRIPT_MEMBER(int, KillEvilness);
 };
 
@@ -485,7 +485,7 @@ class gamescript : public script
  public:
   typedef gamescript scripttype;
   virtual void ReadFrom(inputfile&);
-  const std::list<std::pair<int, teamscript> >& GetTeam() const;
+  const std::list<std::pair<int, teamscript>>& GetTeam() const;
   const std::map<int, dungeonscript>& GetDungeon() const;
   void RandomizeLevels();
   virtual void Save(outputfile&) const;
@@ -494,7 +494,7 @@ class gamescript : public script
  protected:
   virtual const datamap& GetDataMap() const { return DataMap; }
   static datamap DataMap;
-  std::list<std::pair<int, teamscript> > Team;
+  std::list<std::pair<int, teamscript>> Team;
   std::map<int, dungeonscript> Dungeon;
   SCRIPT_MEMBER(int, Dungeons);
   SCRIPT_MEMBER(int, Teams);

--- a/Main/Include/worldmap.h
+++ b/Main/Include/worldmap.h
@@ -26,7 +26,7 @@ class worldmap : public area
 {
  public:
   worldmap(int, int);
-  worldmap();
+  worldmap() = default;
   virtual ~worldmap();
   void Generate();
   void Save(outputfile&) const;

--- a/Main/Include/wterra.h
+++ b/Main/Include/wterra.h
@@ -25,7 +25,7 @@ class wterrain
 {
  public:
   wterrain() : WSquareUnder(0), AnimationFrames(1) { }
-  virtual ~wterrain() { }
+  virtual ~wterrain() = default;
   virtual void Load(inputfile&);
   v2 GetPos() const { return WSquareUnder->GetPos(); }
   void SetWSquareUnder(wsquare* What) { WSquareUnder = What; }

--- a/Main/Source/area.cpp
+++ b/Main/Source/area.cpp
@@ -12,8 +12,6 @@
 
 /* Compiled through areaset.cpp */
 
-area::area() { }
-
 area::area(int InitXSize, int InitYSize)
 {
   Initialize(InitXSize, InitYSize);

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -6348,7 +6348,7 @@ void character::AddOriginalBodyPartID(int I, ulong What)
   }
 }
 
-void character::AddToInventory(const fearray<contentscript<item> >& ItemArray, int SpecialFlags)
+void character::AddToInventory(const fearray<contentscript<item>>& ItemArray, int SpecialFlags)
 {
   for(uint c1 = 0; c1 < ItemArray.Size; ++c1)
     if(ItemArray[c1].IsValid())

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -1410,11 +1410,10 @@ truth commandsystem::SecretKnowledge(character* Char)
     charactervector& Character = game::GetCharacterDrawVector();
     int TeamSize = 0;
 
-    for(std::list<character*>::const_iterator i = Char->GetTeam()->GetMember().begin();
-	i != Char->GetTeam()->GetMember().end(); ++i)
-      if((*i)->IsEnabled())
+    for(character* p : Char->GetTeam()->GetMember())
+      if(p->IsEnabled())
       {
-	Character.push_back(*i);
+	Character.push_back(p);
 	++TeamSize;
       }
 

--- a/Main/Source/cont.cpp
+++ b/Main/Source/cont.cpp
@@ -16,7 +16,6 @@ uchar** continent::TypeBuffer;
 short** continent::AltitudeBuffer;
 uchar** continent::ContinentBuffer;
 
-continent::continent() { }
 continent::continent(int Index) : Index(Index) { }
 long continent::GetSize() const { return Member.size(); }
 int continent::GetGTerrainAmount(int Type) const { return GTerrainAmount[Type]; }

--- a/Main/Source/database.cpp
+++ b/Main/Source/database.cpp
@@ -235,7 +235,7 @@ INST_ADD_MEMBER(olterrain, long);
 INST_ADD_MEMBER(olterrain, v2);
 INST_ADD_MEMBER(olterrain, festring);
 INST_ADD_MEMBER(olterrain, fearray<long>);
-INST_ADD_MEMBER(olterrain, fearray<contentscript<item> >);
+INST_ADD_MEMBER(olterrain, fearray<contentscript<item>>);
 
 INST_ADD_MEMBER(material, int);
 INST_ADD_MEMBER(material, long);

--- a/Main/Source/dungeon.cpp
+++ b/Main/Source/dungeon.cpp
@@ -19,8 +19,6 @@
 #include "femath.h"
 #include "bitmap.h"
 
-dungeon::dungeon() { }
-
 dungeon::dungeon(int Index) : Index(Index)
 {
   Initialize();

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -1185,15 +1185,15 @@ void game::CreateTeams()
 
   const std::list<std::pair<int, teamscript>>& TeamScript = GetGameScript()->GetTeam();
 
-  for(std::list<std::pair<int, teamscript>>::const_iterator i = TeamScript.begin(); i != TeamScript.end(); ++i)
+  for(const std::pair<int, teamscript>& p : TeamScript)
   {
-    for(uint c = 0; c < i->second.GetRelation().size(); ++c)
-      GetTeam(i->second.GetRelation()[c].first)->SetRelation(GetTeam(i->first), i->second.GetRelation()[c].second);
+    for(uint c = 0; c < p.second.GetRelation().size(); ++c)
+      GetTeam(p.second.GetRelation()[c].first)->SetRelation(GetTeam(p.first), p.second.GetRelation()[c].second);
 
-    cint* KillEvilness = i->second.GetKillEvilness();
+    cint* KillEvilness = p.second.GetKillEvilness();
 
     if(KillEvilness)
-      GetTeam(i->first)->SetKillEvilness(*KillEvilness);
+      GetTeam(p.first)->SetKillEvilness(*KillEvilness);
   }
 }
 
@@ -1810,12 +1810,11 @@ void game::CalculateNextDanger()
   if(DataBase && DangerIterator != DangerMap.end())
   {
     character* Char = Proto->Spawn(DataBase->Config, NO_EQUIPMENT|NO_PIC_UPDATE|NO_EQUIPMENT_PIC_UPDATE);
-    std::list<character*>::const_iterator i;
     double DangerSum = Player->GetRelativeDanger(Char, true);
 
-    for(i = Team->GetMember().begin(); i != Team->GetMember().end(); ++i)
-      if((*i)->IsEnabled() && !(*i)->IsTemporary() && !RAND_N(10))
-	DangerSum += (*i)->GetRelativeDanger(Char, true) / 4;
+    for(character* p : Team->GetMember())
+      if(p->IsEnabled() && !p->IsTemporary() && !RAND_N(10))
+	DangerSum += p->GetRelativeDanger(Char, true) / 4;
 
     double CurrentDanger = 1 / DangerSum;
     double NakedDanger = DangerIterator->second.NakedDanger;
@@ -1827,9 +1826,9 @@ void game::CalculateNextDanger()
     Char = Proto->Spawn(DataBase->Config, NO_PIC_UPDATE|NO_EQUIPMENT_PIC_UPDATE);
     DangerSum = Player->GetRelativeDanger(Char, true);
 
-    for(i = Team->GetMember().begin(); i != Team->GetMember().end(); ++i)
-      if((*i)->IsEnabled() && !(*i)->IsTemporary() && !RAND_N(10))
-	DangerSum += (*i)->GetRelativeDanger(Char, true) / 4;
+    for(character* p : Team->GetMember())
+      if(p->IsEnabled() && !p->IsTemporary() && !RAND_N(10))
+	DangerSum += p->GetRelativeDanger(Char, true) / 4;
 
     CurrentDanger = 1 / DangerSum;
     double EquippedDanger = DangerIterator->second.EquippedDanger;
@@ -2141,13 +2140,13 @@ void game::CallForAttention(v2 Pos, int RangeSquare)
   for(int c = 0; c < GetTeams(); ++c)
   {
     if(GetTeam(c)->HasEnemy())
-      for(std::list<character*>::const_iterator i = GetTeam(c)->GetMember().begin(); i != GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled())
+      for(character* p : GetTeam(c)->GetMember())
+	if(p->IsEnabled())
 	{
-	  long ThisDistance = HypotSquare(long((*i)->GetPos().X) - Pos.X, long((*i)->GetPos().Y) - Pos.Y);
+	  long ThisDistance = HypotSquare(long(p->GetPos().X) - Pos.X, long(p->GetPos().Y) - Pos.Y);
 
-	  if(ThisDistance <= RangeSquare && !(*i)->IsGoingSomeWhere())
-	    (*i)->SetGoingTo(Pos);
+	  if(ThisDistance <= RangeSquare && !p->IsGoingSomeWhere())
+	    p->SetGoingTo(Pos);
 	}
   }
 }
@@ -2398,15 +2397,15 @@ void game::DisplayMassacreList(const massacremap& MassacreMap, cchar* Reason, lo
   truth First = true;
   charactervector GraveYard;
 
-  for(massacremap::const_iterator i1 = MassacreMap.begin(); i1 != MassacreMap.end(); ++i1)
+  for(const massacremap::value_type& p : MassacreMap)
   {
-    character* Victim = protocontainer<character>::GetProto(i1->first.Type)->Spawn(i1->first.Config);
-    Victim->SetAssignedName(i1->first.Name);
+    character* Victim = protocontainer<character>::GetProto(p.first.Type)->Spawn(p.first.Config);
+    Victim->SetAssignedName(p.first.Name);
     massacresetentry Entry;
     GraveYard.push_back(Victim);
     Entry.ImageKey = AddToCharacterDrawVector(Victim);
 
-    if(i1->second.Amount == 1)
+    if(p.second.Amount == 1)
     {
       Victim->AddName(Entry.Key, UNARTICLED);
       Victim->AddName(Entry.String, INDEFINITE);
@@ -2414,7 +2413,7 @@ void game::DisplayMassacreList(const massacremap& MassacreMap, cchar* Reason, lo
     else
     {
       Victim->AddName(Entry.Key, PLURAL);
-      Entry.String << i1->second.Amount << ' ' << Entry.Key;
+      Entry.String << p.second.Amount << ' ' << Entry.Key;
     }
 
     if(First)
@@ -2423,7 +2422,7 @@ void game::DisplayMassacreList(const massacremap& MassacreMap, cchar* Reason, lo
       First = false;
     }
 
-    const std::vector<killreason>& Reason = i1->second.Reason;
+    const std::vector<killreason>& Reason = p.second.Reason;
     std::vector<festring>& Details = Entry.Details;
 
     if(Reason.size() == 1)
@@ -2489,10 +2488,9 @@ void game::DisplayMassacreList(const massacremap& MassacreMap, cchar* Reason, lo
   List.AddDescription(SideTopic);
   List.AddDescription(CONST_S(""));
   List.AddDescription("Choose a type of creatures to browse death details.");
-  std::set<massacresetentry>::const_iterator i2;
 
-  for(i2 = MassacreSet.begin(); i2 != MassacreSet.end(); ++i2)
-    List.AddEntry(i2->String, LIGHT_GRAY, 0, i2->ImageKey);
+  for(const massacresetentry& MSE : MassacreSet)
+    List.AddEntry(MSE.String, LIGHT_GRAY, 0, MSE.ImageKey);
 
   for(;;)
   {
@@ -2506,14 +2504,17 @@ void game::DisplayMassacreList(const massacremap& MassacreMap, cchar* Reason, lo
     SubList.SetPageLength(20);
     int Counter = 0;
 
-    for(i2 = MassacreSet.begin(); i2 != MassacreSet.end(); ++i2, ++Counter)
+    for(const massacresetentry& MSE : MassacreSet)
+    {
       if(Counter == Chosen)
       {
-	for(uint c = 0; c < i2->Details.size(); ++c)
-	  SubList.AddEntry(i2->Details[c], LIGHT_GRAY);
+	for(uint c = 0; c < MSE.Details.size(); ++c)
+	  SubList.AddEntry(MSE.Details[c], LIGHT_GRAY);
 
 	break;
       }
+      ++Counter;
+    }
 
     SubList.Draw();
   }
@@ -2705,21 +2706,20 @@ int game::GetMoveCommandKey(int I)
 long game::GetScore()
 {
   double Counter = 0;
-  massacremap::const_iterator i;
   massacremap SumMap = PlayerMassacreMap;
 
-  for(i = PetMassacreMap.begin(); i != PetMassacreMap.end(); ++i)
+  for(const massacremap::value_type& p : PetMassacreMap)
   {
-    killdata& KillData = SumMap[i->first];
-    KillData.Amount += i->second.Amount;
-    KillData.DangerSum += i->second.DangerSum;
+    killdata& KillData = SumMap[p.first];
+    KillData.Amount += p.second.Amount;
+    KillData.DangerSum += p.second.DangerSum;
   }
 
-  for(i = SumMap.begin(); i != SumMap.end(); ++i)
+  for(const massacremap::value_type& p : SumMap)
   {
-    character* Char = protocontainer<character>::GetProto(i->first.Type)->Spawn(i->first.Config);
+    character* Char = protocontainer<character>::GetProto(p.first.Type)->Spawn(p.first.Config);
     int SumOfAttributes = Char->GetSumOfAttributes();
-    Counter += sqrt(i->second.DangerSum / DEFAULT_GENERATION_DANGER) * SumOfAttributes * SumOfAttributes;
+    Counter += sqrt(p.second.DangerSum / DEFAULT_GENERATION_DANGER) * SumOfAttributes * SumOfAttributes;
     delete Char;
   }
 
@@ -2730,8 +2730,8 @@ long game::GetScore()
 
 truth game::TweraifIsFree()
 {
-  for(std::list<character*>::const_iterator i = GetTeam(COLONIST_TEAM)->GetMember().begin(); i != GetTeam(COLONIST_TEAM)->GetMember().end(); ++i)
-    if((*i)->IsEnabled())
+  for(character* p : GetTeam(COLONIST_TEAM)->GetMember())
+    if(p->IsEnabled())
       return false;
 
   return true;
@@ -3242,10 +3242,9 @@ truth game::FillPetVector(cchar* Verb)
   PetVector.clear();
   team* Team = GetTeam(PLAYER_TEAM);
 
-  for(std::list<character*>::const_iterator i = Team->GetMember().begin();
-      i != Team->GetMember().end(); ++i)
-    if((*i)->IsEnabled() && !(*i)->IsPlayer() && (*i)->CanBeSeenByPlayer())
-      PetVector.push_back(*i);
+  for(character* p : Team->GetMember())
+    if(p->IsEnabled() && !p->IsPlayer() && p->CanBeSeenByPlayer())
+      PetVector.push_back(p);
 
   if(PetVector.empty())
   {
@@ -3547,11 +3546,8 @@ double game::GetGameSituationDanger()
 
   for(int c1 = 0; c1 < GetTeams(); ++c1)
     if(GetTeam(c1)->GetRelation(GetTeam(PLAYER_TEAM)) == HOSTILE)
-      for(std::list<character*>::const_iterator i1 = GetTeam(c1)->GetMember().begin();
-	  i1 != GetTeam(c1)->GetMember().end(); ++i1)
+      for(character* Enemy : GetTeam(c1)->GetMember())
       {
-	character* Enemy = *i1;
-
 	if(Enemy->IsEnabled() && Enemy->CanAttack()
 	   && (Enemy->CanMove() || Enemy->GetPos().IsAdjacent(PlayerPos)))
 	{
@@ -3567,11 +3563,8 @@ double game::GetGameSituationDanger()
 
 	  for(int c2 = 0; c2 < GetTeams(); ++c2)
 	    if(GetTeam(c2)->GetRelation(GetTeam(c1)) == HOSTILE)
-	      for(std::list<character*>::const_iterator i2 = GetTeam(c2)->GetMember().begin();
-		  i2 != GetTeam(c2)->GetMember().end(); ++i2)
+              for(character* Friend : GetTeam(c2)->GetMember())
 	      {
-		character* Friend = *i2;
-
 		if(Friend->IsEnabled() && !Friend->IsPlayer() && Friend->CanAttack()
 		   && (Friend->CanMove() || Friend->GetPos().IsAdjacent(EnemyPos)))
 		{

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -50,8 +50,8 @@
 #include "balance.h"
 #include "confdef.h"
 
-#define SAVE_FILE_VERSION 123 // Increment this if changes make savefiles incompatible
-#define BONE_FILE_VERSION 109 // Increment this if changes make bonefiles incompatible
+#define SAVE_FILE_VERSION 124 // Increment this if changes make savefiles incompatible
+#define BONE_FILE_VERSION 110 // Increment this if changes make bonefiles incompatible
 
 #define LOADED 0
 #define NEW_GAME 1

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -1183,9 +1183,9 @@ void game::CreateTeams()
     if(c != 1)
       Team[1]->SetRelation(Team[c], HOSTILE);
 
-  const std::list<std::pair<int, teamscript> >& TeamScript = GetGameScript()->GetTeam();
+  const std::list<std::pair<int, teamscript>>& TeamScript = GetGameScript()->GetTeam();
 
-  for(std::list<std::pair<int, teamscript> >::const_iterator i = TeamScript.begin(); i != TeamScript.end(); ++i)
+  for(std::list<std::pair<int, teamscript>>::const_iterator i = TeamScript.begin(); i != TeamScript.end(); ++i)
   {
     for(uint c = 0; c < i->second.GetRelation().size(); ++c)
       GetTeam(i->second.GetRelation()[c].first)->SetRelation(GetTeam(i->first), i->second.GetRelation()[c].second);

--- a/Main/Source/gods.cpp
+++ b/Main/Source/gods.cpp
@@ -953,11 +953,9 @@ void scabies::PrayGoodEffect()
   {
     for(int c = 0; c < game::GetTeams(); ++c)
       if(PLAYER->GetTeam()->GetRelation(game::GetTeam(c)) == HOSTILE)
-	for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
+        for(character* Char : game::GetTeam(c)->GetMember())
 	{
-	  character* Char = *i;
-
-	  if((*i)->IsEnabled() && !Char->IsImmuneToLeprosy())
+	  if(Char->IsEnabled() && !Char->IsImmuneToLeprosy())
 	    Char->GainIntrinsic(LEPROSY);
 	}
 

--- a/Main/Source/human.cpp
+++ b/Main/Source/human.cpp
@@ -138,18 +138,18 @@ void humanoid::Load(inputfile& SaveFile)
   SaveFile >> SWeaponSkill;
 
   if(GetRightWielded())
-    for(std::list<sweaponskill*>::iterator i = SWeaponSkill.begin(); i != SWeaponSkill.end(); ++i)
-      if((*i)->IsSkillOf(GetRightWielded()))
+    for(sweaponskill* p : SWeaponSkill)
+      if(p->IsSkillOf(GetRightWielded()))
       {
-	SetCurrentRightSWeaponSkill(*i);
+	SetCurrentRightSWeaponSkill(p);
 	break;
       }
 
   if(GetLeftWielded())
-    for(std::list<sweaponskill*>::iterator i = SWeaponSkill.begin(); i != SWeaponSkill.end(); ++i)
-      if((*i)->IsSkillOf(GetLeftWielded()))
+    for(sweaponskill* p : SWeaponSkill)
+      if(p->IsSkillOf(GetLeftWielded()))
       {
-	SetCurrentLeftSWeaponSkill(*i);
+	SetCurrentLeftSWeaponSkill(p);
 	break;
       }
 }
@@ -252,9 +252,9 @@ truth petrus::HealFully(character* ToBeHealed)
     {
       bodypart* BodyPart = 0;
 
-      for(std::list<ulong>::const_iterator i = ToBeHealed->GetOriginalBodyPartID(c).begin(); i != ToBeHealed->GetOriginalBodyPartID(c).end(); ++i)
+      for(ulong ID : ToBeHealed->GetOriginalBodyPartID(c))
       {
-	BodyPart = static_cast<bodypart*>(ToBeHealed->SearchForItem(*i));
+	BodyPart = static_cast<bodypart*>(ToBeHealed->SearchForItem(ID));
 
 	if(BodyPart)
 	  break;
@@ -655,9 +655,9 @@ void priest::BeTalkedTo()
     {
       truth HasOld = false;
 
-      for(std::list<ulong>::const_iterator i = PLAYER->GetOriginalBodyPartID(c).begin(); i != PLAYER->GetOriginalBodyPartID(c).end(); ++i)
+      for(ulong ID : PLAYER->GetOriginalBodyPartID(c))
       {
-	bodypart* OldBodyPart = static_cast<bodypart*>(PLAYER->SearchForItem(*i));
+	bodypart* OldBodyPart = static_cast<bodypart*>(PLAYER->SearchForItem(ID));
 
 	if(OldBodyPart)
 	{
@@ -792,14 +792,9 @@ void communist::BeTalkedTo()
   {
     ADD_MESSAGE("%s seems to be very friendly. \"%s make good communist. %s go with %s!\"", CHAR_DESCRIPTION(DEFINITE), PLAYER->GetAssignedName().CStr(), CHAR_NAME(UNARTICLED), PLAYER->GetAssignedName().CStr());
 
-    for(std::list<character*>::const_iterator i = GetTeam()->GetMember().begin(); i != GetTeam()->GetMember().end();)
-      if(*i != this)
-      {
-	character* Char = *i++;
+    for(character* Char : GetTeam()->GetMember())
+      if(Char != this)
 	Char->ChangeTeam(PLAYER->GetTeam());
-      }
-      else
-	++i;
 
     ChangeTeam(PLAYER->GetTeam());
   }
@@ -825,15 +820,15 @@ void tourist::BeTalkedTo()
 	  character* Spider = 0;
 	  
 	  //check all enabled members of PLAYER_TEAM	
-  	  for(std::list<character*>::const_iterator i = game::GetTeam(PLAYER_TEAM)->GetMember().begin(); i != game::GetTeam(PLAYER_TEAM)->GetMember().end(); ++i)
-   		 if((*i)->IsEnabled() && !(*i)->IsPlayer() && (*i)->IsSpider() 
-			&& ((*i)->GetConfig() != LARGE && (*i)->GetConfig() != GIANT)) // check for lobh-se first
-      		Spider = *i;
+  	  for(character* p : game::GetTeam(PLAYER_TEAM)->GetMember())
+   		 if(p->IsEnabled() && !p->IsPlayer() && p->IsSpider()
+			&& (p->GetConfig() != LARGE && p->GetConfig() != GIANT)) // check for lobh-se first
+      		Spider = p;
      
 	  if (!Spider) { // lobh-se not found		
-  	  for(std::list<character*>::const_iterator i = game::GetTeam(PLAYER_TEAM)->GetMember().begin(); i != game::GetTeam(PLAYER_TEAM)->GetMember().end(); ++i)
-   		 if((*i)->IsEnabled() && !(*i)->IsPlayer() && (*i)->IsSpider()) // check for any spider
-      		Spider = *i; 
+  	  for(character* p : game::GetTeam(PLAYER_TEAM)->GetMember())
+   		 if(p->IsEnabled() && !p->IsPlayer() && p->IsSpider()) // check for any spider
+      		Spider = p;
       }
       		
 	  static long Said;
@@ -2620,11 +2615,10 @@ item* humanoid::SevereBodyPart(int BodyPartIndex, truth ForceDisappearance, stac
 humanoid::humanoid(const humanoid& Humanoid) : mybase(Humanoid), CurrentRightSWeaponSkill(0), CurrentLeftSWeaponSkill(0)
 {
   SWeaponSkill.resize(Humanoid.SWeaponSkill.size());
-  std::list<sweaponskill*>::iterator i1 = SWeaponSkill.begin();
   std::list<sweaponskill*>::const_iterator i2 = Humanoid.SWeaponSkill.begin();
 
-  for(; i1 != SWeaponSkill.end(); ++i1, ++i2)
-    *i1 = new sweaponskill(**i2);
+  for(sweaponskill*& p : SWeaponSkill)
+    p = new sweaponskill(**i2++);
 }
 
 cfestring& humanoid::GetDeathMessage() const
@@ -2635,16 +2629,14 @@ cfestring& humanoid::GetDeathMessage() const
 
 int humanoid::GetSWeaponSkillLevel(citem* Item) const
 {
-  std::list<sweaponskill*>::const_iterator i;
-
-  for(i = SWeaponSkill.begin(); i != SWeaponSkill.end(); ++i)
-    if((*i)->IsSkillOf(Item))
-      return (*i)->GetLevel();
+  for(sweaponskill* p : SWeaponSkill)
+    if(p->IsSkillOf(Item))
+      return p->GetLevel();
 
   for(idholder* I = Item->GetCloneMotherID(); I; I = I->Next)
-    for(i = SWeaponSkill.begin(); i != SWeaponSkill.end(); ++i)
-      if((*i)->IsSkillOfCloneMother(Item, I->ID))
-	return (*i)->GetLevel();
+    for(sweaponskill* p : SWeaponSkill)
+      if(p->IsSkillOfCloneMother(Item, I->ID))
+	return p->GetLevel();
 
   return 0;
 }
@@ -3226,23 +3218,23 @@ void darkmage::GetAICommand()
   {
     if(GetTeam()->GetRelation(game::GetTeam(c)) == HOSTILE)
     {
-      for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled())
+      for(character* p : game::GetTeam(c)->GetMember())
+	if(p->IsEnabled())
 	{
-	  long ThisDistance = Max<long>(abs((*i)->GetPos().X - Pos.X), abs((*i)->GetPos().Y - Pos.Y));
+	  long ThisDistance = Max<long>(abs(p->GetPos().X - Pos.X), abs(p->GetPos().Y - Pos.Y));
 
-	  if((ThisDistance < NearestEnemyDistance || (ThisDistance == NearestEnemyDistance && !(RAND() % 3))) && (*i)->CanBeSeenBy(this))
+	  if((ThisDistance < NearestEnemyDistance || (ThisDistance == NearestEnemyDistance && !(RAND() % 3))) && p->CanBeSeenBy(this))
 	  {
-	    NearestEnemy = *i;
+	    NearestEnemy = p;
 	    NearestEnemyDistance = ThisDistance;
 	  }
 	}
     }
     else if(GetTeam()->GetRelation(game::GetTeam(c)) == FRIEND)
     {
-      for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled() && (*i)->CanBeSeenBy(this))
-	  Friend.push_back(*i);
+      for(character* p : game::GetTeam(c)->GetMember())
+	if(p->IsEnabled() && p->CanBeSeenBy(this))
+	  Friend.push_back(p);
     }
   }
 
@@ -3678,8 +3670,8 @@ truth communist::MustBeRemovedFromBone() const
 
 truth humanoid::PreProcessForBone()
 {
-  for(std::list<sweaponskill*>::iterator i = SWeaponSkill.begin(); i != SWeaponSkill.end(); ++i)
-    (*i)->PreProcessForBone();
+  for(sweaponskill* p : SWeaponSkill)
+    p->PreProcessForBone();
 
   return character::PreProcessForBone();
 }
@@ -3881,20 +3873,18 @@ void humanoid::EnsureCurrentSWeaponSkillIsCorrect(sweaponskill*& Skill, citem* W
       if(Skill)
 	EnsureCurrentSWeaponSkillIsCorrect(Skill, 0);
 
-      std::list<sweaponskill*>::iterator i;
-
-      for(i = SWeaponSkill.begin(); i != SWeaponSkill.end(); ++i)
-	if((*i)->IsSkillOf(Wielded))
+      for(sweaponskill* p : SWeaponSkill)
+	if(p->IsSkillOf(Wielded))
 	{
-	  Skill = *i;
+	  Skill = p;
 	  return;
 	}
 
       for(idholder* I = Wielded->GetCloneMotherID(); I; I = I->Next)
-	for(i = SWeaponSkill.begin(); i != SWeaponSkill.end(); ++i)
-	  if((*i)->IsSkillOfCloneMother(Wielded, I->ID))
+	for(sweaponskill* p : SWeaponSkill)
+	  if(p->IsSkillOfCloneMother(Wielded, I->ID))
 	  {
-	    Skill = new sweaponskill(**i);
+	    Skill = new sweaponskill(*p);
 	    Skill->SetID(Wielded->GetID());
 	    SWeaponSkill.push_back(Skill);
 	    return;
@@ -3921,8 +3911,8 @@ void humanoid::EnsureCurrentSWeaponSkillIsCorrect(sweaponskill*& Skill, citem* W
 
 humanoid::~humanoid()
 {
-  for(std::list<sweaponskill*>::iterator i = SWeaponSkill.begin(); i != SWeaponSkill.end(); ++i)
-    delete *i;
+  for(sweaponskill* p : SWeaponSkill)
+    delete p;
 }
 
 truth petrus::MoveTowardsHomePos()
@@ -4022,14 +4012,14 @@ void necromancer::GetAICommand()
   for(int c = 0; c < game::GetTeams(); ++c)
     if(GetTeam()->GetRelation(game::GetTeam(c)) == HOSTILE)
     {
-      for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled())
+      for(character* p : game::GetTeam(c)->GetMember())
+	if(p->IsEnabled())
 	{
-	  long ThisDistance = Max<long>(abs((*i)->GetPos().X - Pos.X), abs((*i)->GetPos().Y - Pos.Y));
+	  long ThisDistance = Max<long>(abs(p->GetPos().X - Pos.X), abs(p->GetPos().Y - Pos.Y));
 
-	  if((ThisDistance < NearestEnemyDistance || (ThisDistance == NearestEnemyDistance && !(RAND() % 3))) && (*i)->CanBeSeenBy(this))
+	  if((ThisDistance < NearestEnemyDistance || (ThisDistance == NearestEnemyDistance && !(RAND() % 3))) && p->CanBeSeenBy(this))
 	  {
-	    NearestEnemy = *i;
+	    NearestEnemy = p;
 	    NearestEnemyDistance = ThisDistance;
 	  }
 	}
@@ -4133,14 +4123,13 @@ void necromancer::GetAICommand()
 truth necromancer::TryToRaiseZombie()
 {
   for(int c = 0; c < game::GetTeams(); ++c)
-    for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin();
-	i != game::GetTeam(c)->GetMember().end(); ++i)
-      if(!(*i)->IsEnabled() && (*i)->GetMotherEntity()
-	 && (*i)->GetMotherEntity()->Exists()
+    for(character* p : game::GetTeam(c)->GetMember())
+      if(!p->IsEnabled() && p->GetMotherEntity()
+	 && p->GetMotherEntity()->Exists()
 	 && (GetConfig() == MASTER_NECROMANCER
-	     || (*i)->GetMotherEntity()->GetSquareUnderEntity()->CanBeSeenBy(this)))
+	     || p->GetMotherEntity()->GetSquareUnderEntity()->CanBeSeenBy(this)))
       {
-	character* Zombie = (*i)->GetMotherEntity()->TryNecromancy(this);
+	character* Zombie = p->GetMotherEntity()->TryNecromancy(this);
 
 	if(Zombie)
 	{
@@ -4446,11 +4435,10 @@ character* humanoid::CreateZombie() const
     Zombie->CWeaponSkill[c] = CWeaponSkill[c];
 
   Zombie->SWeaponSkill.resize(SWeaponSkill.size());
-  std::list<sweaponskill*>::iterator i1 = Zombie->SWeaponSkill.begin();
-  std::list<sweaponskill*>::const_iterator i2 = SWeaponSkill.begin();
+  std::list<sweaponskill*>::iterator i = Zombie->SWeaponSkill.begin();
 
-  for(; i2 != SWeaponSkill.end(); ++i1, ++i2)
-    *i1 = new sweaponskill(**i2);
+  for(sweaponskill* p2 : SWeaponSkill)
+    *i++ = new sweaponskill(*p2);
 
   memcpy(Zombie->BaseExperience,
 	 BaseExperience,

--- a/Main/Source/level.cpp
+++ b/Main/Source/level.cpp
@@ -514,7 +514,7 @@ truth level::MakeRoom(const roomscript* RoomScript)
   if(ItemMap)
   {
     v2 ItemPos(Pos + *ItemMap->GetPos());
-    const fearray<contentscript<item> >* ItemScript;
+    const fearray<contentscript<item>>* ItemScript;
 
     for(int x = 0; x < ItemMap->GetSize()->X; ++x)
     {

--- a/Main/Source/level.cpp
+++ b/Main/Source/level.cpp
@@ -592,29 +592,26 @@ truth level::MakeRoom(const roomscript* RoomScript)
     }
   }
 
-  const std::list<squarescript> Square = RoomScript->GetSquare();
-
-  for(std::list<squarescript>::const_iterator i = Square.begin(); i != Square.end(); ++i)
+  for(const squarescript& Script : RoomScript->GetSquare())
   {
     game::BusyAnimation();
-    const squarescript* Script = &*i;
-    const interval* ScriptTimes = Script->GetTimes();
+    const interval* ScriptTimes = Script.GetTimes();
     int Times = ScriptTimes ? ScriptTimes->Randomize() : 1;
 
     for(int t = 0; t < Times; ++t)
     {
       v2 SquarePos;
 
-      if(Script->GetPosition()->GetRandom())
+      if(Script.GetPosition()->GetRandom())
       {
-	const rect* ScriptBorders = Script->GetPosition()->GetBorders();
+	const rect* ScriptBorders = Script.GetPosition()->GetBorders();
 	rect Borders = ScriptBorders ? *ScriptBorders + Pos : rect(Pos, Pos + Size - v2(1, 1));
-	SquarePos = GetRandomSquare(0, Script->GetPosition()->GetFlags(), &Borders);
+	SquarePos = GetRandomSquare(0, Script.GetPosition()->GetFlags(), &Borders);
       }
       else
-	SquarePos = Pos + Script->GetPosition()->GetVector();
+	SquarePos = Pos + Script.GetPosition()->GetVector();
 
-      Map[SquarePos.X][SquarePos.Y]->ApplyScript(Script, RoomClass);
+      Map[SquarePos.X][SquarePos.Y]->ApplyScript(&Script, RoomClass);
     }
   }
 
@@ -1085,9 +1082,9 @@ truth level::CollectCreatures(charactervector& CharacterArray, character* Leader
   if(!AllowHostiles)
     for(c = 0; c < game::GetTeams(); ++c)
       if(Leader->GetTeam()->GetRelation(game::GetTeam(c)) == HOSTILE)
-	for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	  if((*i)->IsEnabled() && Leader->CanBeSeenBy(*i)
-	     && Leader->SquareUnderCanBeSeenBy(*i, true) && (*i)->CanFollow())
+        for(character* p : game::GetTeam(c)->GetMember())
+	  if(p->IsEnabled() && Leader->CanBeSeenBy(p)
+	     && Leader->SquareUnderCanBeSeenBy(p, true) && p->CanFollow())
 	  {
 	    ADD_MESSAGE("You can't escape when there are hostile creatures nearby.");
 	    return false;
@@ -1105,22 +1102,22 @@ truth level::CollectCreatures(charactervector& CharacterArray, character* Leader
 
   for(c = 0; c < game::GetTeams(); ++c)
     if(game::GetTeam(c) == Leader->GetTeam() || Leader->GetTeam()->GetRelation(game::GetTeam(c)) == HOSTILE)
-      for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled() && *i != Leader
+      for(character* p : game::GetTeam(c)->GetMember())
+	if(p->IsEnabled() && p != Leader
 	   && (TakeAll
-	       || (Leader->CanBeSeenBy(*i)
-		   && Leader->SquareUnderCanBeSeenBy(*i, true)))
-	   && (*i)->CanFollow()
-	   && (*i)->GetCommandFlags() & FOLLOW_LEADER)
+	       || (Leader->CanBeSeenBy(p)
+		   && Leader->SquareUnderCanBeSeenBy(p, true)))
+	   && p->CanFollow()
+	   && p->GetCommandFlags() & FOLLOW_LEADER)
 	{
-	  if((*i)->GetAction() && (*i)->GetAction()->IsVoluntary())
-	    (*i)->GetAction()->Terminate(false);
+	  if(p->GetAction() && p->GetAction()->IsVoluntary())
+	    p->GetAction()->Terminate(false);
 
-	  if(!(*i)->GetAction())
+	  if(!p->GetAction())
 	  {
-	    ADD_MESSAGE("%s follows you.", (*i)->CHAR_NAME(DEFINITE));
-	    CharacterArray.push_back(*i);
-	    (*i)->Remove();
+	    ADD_MESSAGE("%s follows you.", p->CHAR_NAME(DEFINITE));
+	    CharacterArray.push_back(p);
+	    p->Remove();
 	  }
 	}
 
@@ -1841,23 +1838,17 @@ void level::GenerateDungeon(int Index)
     const levelscript* LevelBase = static_cast<const levelscript*>(LevelScript->GetBase());
 
     if(LevelBase)
-    {
-      const std::list<squarescript>& Square = LevelBase->GetSquare();
-
-      for(std::list<squarescript>::const_iterator i = Square.begin(); i != Square.end(); ++i)
+      for(const squarescript& Script : LevelBase->GetSquare())
       {
 	game::BusyAnimation();
-	ApplyLSquareScript(&*i);
+	ApplyLSquareScript(&Script);
       }
-    }
   }
 
-  const std::list<squarescript>& Square = LevelScript->GetSquare();
-
-  for(std::list<squarescript>::const_iterator i = Square.begin(); i != Square.end(); ++i)
+  for(const squarescript& Script : LevelScript->GetSquare())
   {
     game::BusyAnimation();
-    ApplyLSquareScript(&*i);
+    ApplyLSquareScript(&Script);
   }
 
   for(c = 0; c < AttachQueue.size(); ++c)
@@ -2422,9 +2413,9 @@ truth sunbeamcontroller::ReSunEmitation;
 
 void level::ForceEmitterNoxify(const emittervector& Emitter) const
 {
-  for(emittervector::const_iterator i = Emitter.begin(); i != Emitter.end(); ++i)
+  for(const emitter& e : Emitter)
   {
-    ulong ID = i->ID;
+    ulong ID = e.ID;
     lsquare* Square = GetLSquare(ExtractPosFromEmitterID(ID));
 
     if(ID & SECONDARY_SUN_LIGHT)
@@ -2436,9 +2427,9 @@ void level::ForceEmitterNoxify(const emittervector& Emitter) const
 
 void level::ForceEmitterEmitation(const emittervector& Emitter, const sunemittervector& SunEmitter, ulong IDFlags) const
 {
-  for(emittervector::const_iterator i = Emitter.begin(); i != Emitter.end(); ++i)
+  for(const emitter& e : Emitter)
   {
-    ulong ID = i->ID;
+    ulong ID = e.ID;
     lsquare* Square = GetLSquare(ExtractPosFromEmitterID(ID));
 
     if(ID & SECONDARY_SUN_LIGHT)
@@ -2455,9 +2446,9 @@ void level::ForceEmitterEmitation(const emittervector& Emitter, const sunemitter
     stackcontroller::LevelYSize = YSize;
     sunbeamcontroller::ReSunEmitation = true;
 
-    for(sunemittervector::const_iterator i = SunEmitter.begin(); i != SunEmitter.end(); ++i)
+    for(sunemittervector::value_type SE : SunEmitter)
     {
-      ulong ID = (*i & ~(EMITTER_SHADOW_BITS|EMITTER_SQUARE_PART_BITS)) | RE_SUN_EMITATED, SourceFlags;
+      ulong ID = (SE & ~(EMITTER_SHADOW_BITS|EMITTER_SQUARE_PART_BITS)) | RE_SUN_EMITATED, SourceFlags;
       int X, Y;
 
       if(ID & ID_X_COORDINATE)
@@ -2537,9 +2528,9 @@ void level::UpdateLOS()
 
   if(PLAYER->StateIsActivated(INFRA_VISION))
     for(int c = 0; c < game::GetTeams(); ++c)
-      for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled())
-	  (*i)->SendNewDrawRequest();
+      for(character* p : game::GetTeam(c)->GetMember())
+	if(p->IsEnabled())
+	  p->SendNewDrawRequest();
 }
 
 void level::EnableGlobalRain()

--- a/Main/Source/lsquare.cpp
+++ b/Main/Source/lsquare.cpp
@@ -960,7 +960,7 @@ void lsquare::ApplyScript(const squarescript* SquareScript, room* Room)
       Room->SetMasterID(Char->GetID());
   }
 
-  const fearray<contentscript<item> >* Items = SquareScript->GetItems();
+  const fearray<contentscript<item>>* Items = SquareScript->GetItems();
 
   if(Items)
     for(uint c1 = 0; c1 < Items->Size; ++c1)

--- a/Main/Source/lterra.cpp
+++ b/Main/Source/lterra.cpp
@@ -87,7 +87,7 @@ truth lterrain::SitOn(character* Sitter)
 void olterrain::Break()
 {
   lsquare* Square = GetLSquareUnder();
-  const fearray<contentscript<item> >& ItemArray = GetLeftOverItems();
+  const fearray<contentscript<item>>& ItemArray = GetLeftOverItems();
 
   for(uint c1 = 0; c1 < ItemArray.Size; ++c1)
     if(ItemArray[c1].IsValid())

--- a/Main/Source/lterras.cpp
+++ b/Main/Source/lterras.cpp
@@ -1029,7 +1029,7 @@ truth olterraincontainer::Open(character* Opener)
   return Success;
 }
 
-void olterraincontainer::SetItemsInside(const fearray<contentscript<item> >& ItemArray, int SpecialFlags)
+void olterraincontainer::SetItemsInside(const fearray<contentscript<item>>& ItemArray, int SpecialFlags)
 {
   GetContained()->Clean();
 

--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -1690,7 +1690,7 @@ int materialcontainer::GetSpoilLevel() const
   return Max(MainMaterial->GetSpoilLevel(), SecondaryMaterial ? SecondaryMaterial->GetSpoilLevel() : 0);
 }
 
-void itemcontainer::SetItemsInside(const fearray<contentscript<item> >& ItemArray, int SpecialFlags)
+void itemcontainer::SetItemsInside(const fearray<contentscript<item>>& ItemArray, int SpecialFlags)
 {
   GetContained()->Clean();
 

--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -918,13 +918,12 @@ void magicalwhistle::BlowEffect(character* Whistler)
   else if(PLAYER->CanHear())
     ADD_MESSAGE("You hear a strange tune playing.");
 
-  const std::list<character*>& Member = Whistler->GetTeam()->GetMember();
   std::vector<distancepair> ToSort;
   v2 Pos = Whistler->GetPos();
 
-  for(std::list<character*>::const_iterator i = Member.begin(); i != Member.end(); ++i)
-    if((*i)->IsEnabled() && Whistler != *i)
-      ToSort.push_back(distancepair((Pos - (*i)->GetPos()).GetLengthSquare(), *i));
+  for(character* p : Whistler->GetTeam()->GetMember())
+    if(p->IsEnabled() && Whistler != p)
+      ToSort.push_back(distancepair((Pos - p->GetPos()).GetLengthSquare(), p));
 
   if(ToSort.size() > 5)
     std::sort(ToSort.begin(), ToSort.end());

--- a/Main/Source/nonhuman.cpp
+++ b/Main/Source/nonhuman.cpp
@@ -561,10 +561,14 @@ void genetrixvesana::GetAICommand()
     {
       for(int c2 = 0; c2 < game::GetTeams() && NumberOfPlants; ++c2)
 	if(GetTeam()->GetRelation(game::GetTeam(c2)) == HOSTILE)
-	  for(std::list<character*>::const_iterator i = game::GetTeam(c2)->GetMember().begin(); i != game::GetTeam(c2)->GetMember().end() && NumberOfPlants; ++i)
-	    if((*i)->IsEnabled())
+          for(character* p : game::GetTeam(c2)->GetMember())
+          {
+            if(!NumberOfPlants)
+              break;
+
+	    if(p->IsEnabled())
 	    {
-	      lsquare* LSquare = (*i)->GetNeighbourLSquare(RAND() % GetNeighbourSquares());
+	      lsquare* LSquare = p->GetNeighbourLSquare(RAND() % GetNeighbourSquares());
 
 	      if(LSquare && (LSquare->GetWalkability() & WALK) && !LSquare->GetCharacter())
 	      {
@@ -588,15 +592,16 @@ void genetrixvesana::GetAICommand()
 
 		if(NewPlant->CanBeSeenByPlayer())
 		{
-		  if((*i)->IsPlayer())
+		  if(p->IsPlayer())
 		    ADD_MESSAGE("%s sprouts from the ground near you.", NewPlant->CHAR_NAME(INDEFINITE));
-		  else if((*i)->CanBeSeenByPlayer())
-		    ADD_MESSAGE("%s sprouts from the ground near %s.", NewPlant->CHAR_NAME(INDEFINITE), (*i)->CHAR_NAME(DEFINITE));
+		  else if(p->CanBeSeenByPlayer())
+		    ADD_MESSAGE("%s sprouts from the ground near %s.", NewPlant->CHAR_NAME(INDEFINITE), p->CHAR_NAME(DEFINITE));
 		  else
 		    ADD_MESSAGE("%s sprouts from the ground.", NewPlant->CHAR_NAME(INDEFINITE));
 		}
 	      }
 	    }
+          }
     }
 
     EditAP(-2000);
@@ -1707,14 +1712,14 @@ truth bunny::CheckForMatePartner()
 
     for(int c = 0; c < game::GetTeams(); ++c)
       if(GetTeam()->GetRelation(game::GetTeam(c)) != HOSTILE)
-	for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	  if((*i)->IsEnabled() && (*i)->IsBunny() && (*i)->GetConfig() == ADULT_FEMALE && (*i)->GetNP() > SATIATED_LEVEL)
+        for(character* p : game::GetTeam(c)->GetMember())
+	  if(p->IsEnabled() && p->IsBunny() && p->GetConfig() == ADULT_FEMALE && p->GetNP() > SATIATED_LEVEL)
 	  {
-	    double Danger = (*i)->GetRelativeDanger(this, true);
+	    double Danger = p->GetRelativeDanger(this, true);
 
 	    if(Danger > BestPartnerDanger)
 	    {
-	      BestPartner = *i;
+	      BestPartner = p;
 	      BestPartnerDanger = Danger;
 	    }
 	  }
@@ -2075,24 +2080,24 @@ void mysticfrog::GetAICommand()
   {
     if(GetTeam()->GetRelation(game::GetTeam(c)) == HOSTILE)
     {
-      for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled())
+      for(character* p : game::GetTeam(c)->GetMember())
+	if(p->IsEnabled())
 	{
 	  Enemies = true;
-	  long ThisDistance = Max<long>(abs((*i)->GetPos().X - Pos.X), abs((*i)->GetPos().Y - Pos.Y));
+	  long ThisDistance = Max<long>(abs(p->GetPos().X - Pos.X), abs(p->GetPos().Y - Pos.Y));
 
-	  if((ThisDistance < NearestEnemyDistance || (ThisDistance == NearestEnemyDistance && !(RAND() % 3))) && (*i)->CanBeSeenBy(this))
+	  if((ThisDistance < NearestEnemyDistance || (ThisDistance == NearestEnemyDistance && !(RAND() % 3))) && p->CanBeSeenBy(this))
 	  {
-	    NearestEnemy = *i;
+	    NearestEnemy = p;
 	    NearestEnemyDistance = ThisDistance;
 	  }
 	}
     }
     else if(GetTeam()->GetRelation(game::GetTeam(c)) == FRIEND)
     {
-      for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin(); i != game::GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled() && (*i)->CanBeSeenBy(this))
-	  Friend.push_back(*i);
+      for(character* p : game::GetTeam(c)->GetMember())
+	if(p->IsEnabled() && p->CanBeSeenBy(this))
+	  Friend.push_back(p);
     }
   }
 
@@ -2230,19 +2235,18 @@ void spider::GetAICommand()
 
   for(int c = 0; c < game::GetTeams(); ++c)
     if(GetTeam()->GetRelation(game::GetTeam(c)) == HOSTILE)
-      for(std::list<character*>::const_iterator i = game::GetTeam(c)->GetMember().begin();
-	  i != game::GetTeam(c)->GetMember().end(); ++i)
-	if((*i)->IsEnabled() && GetAttribute(WISDOM) < (*i)->GetAttackWisdomLimit())
+      for(character* p : game::GetTeam(c)->GetMember())
+	if(p->IsEnabled() && GetAttribute(WISDOM) < p->GetAttackWisdomLimit())
 	{
-	  long ThisDistance = Max<long>(abs((*i)->GetPos().X - Pos.X), abs((*i)->GetPos().Y - Pos.Y));
+	  long ThisDistance = Max<long>(abs(p->GetPos().X - Pos.X), abs(p->GetPos().Y - Pos.Y));
 	  ++Hostiles;
 
 	  if((ThisDistance < NearestDistance
 	      || (ThisDistance == NearestDistance && !(RAND() % 3)))
-	     && (*i)->CanBeSeenBy(this, false, IsGoingSomeWhere())
-	     && (!IsGoingSomeWhere() || HasClearRouteTo((*i)->GetPos())))
+	     && p->CanBeSeenBy(this, false, IsGoingSomeWhere())
+	     && (!IsGoingSomeWhere() || HasClearRouteTo(p->GetPos())))
 	  {
-	    NearestChar = *i;
+	    NearestChar = p;
 	    NearestDistance = ThisDistance;
 	  }
 	}

--- a/Main/Source/rooms.cpp
+++ b/Main/Source/rooms.cpp
@@ -922,11 +922,9 @@ character* cathedral::FindRandomExplosiveReceiver() const
 {
   std::vector<character*> ListOfDwarfs;
 
-  for(std::list<character*>::const_iterator i
-	= game::GetTeam(ATTNAM_TEAM)->GetMember().begin();
-      i != game::GetTeam(ATTNAM_TEAM)->GetMember().end(); ++i)
-    if((*i)->IsEnabled() && (*i)->IsKamikazeDwarf())
-      ListOfDwarfs.push_back(*i);
+  for(character* p : game::GetTeam(ATTNAM_TEAM)->GetMember())
+    if(p->IsEnabled() && p->IsKamikazeDwarf())
+      ListOfDwarfs.push_back(p);
 
   if(ListOfDwarfs.empty())
     return 0;

--- a/Main/Source/script.cpp
+++ b/Main/Source/script.cpp
@@ -995,8 +995,6 @@ void levelscript::Load(inputfile& SaveFile)
       RoomScript.SetBase(RoomDefault);
 }
 
-dungeonscript::dungeonscript() { }
-dungeonscript::~dungeonscript() { }
 const std::map<int, levelscript>& dungeonscript::GetLevel() const { return Level; }
 
 void dungeonscript::InitDataMap()

--- a/Main/Source/script.cpp
+++ b/Main/Source/script.cpp
@@ -159,14 +159,14 @@ scriptmemberbase* script::GetDataFromMap(const datamap& DataMap, cchar* Identifi
 
 void script::SaveDataMap(const datamap& DataMap, outputfile& SaveFile) const
 {
-  for(datamap::const_iterator i = DataMap.begin(); i != DataMap.end(); ++i)
-    (this->*i->second).Save(SaveFile);
+  for(const datamap::value_type& p : DataMap)
+    (this->*p.second).Save(SaveFile);
 }
 
 void script::LoadDataMap(const datamap& DataMap, inputfile& SaveFile)
 {
-  for(datamap::const_iterator i = DataMap.begin(); i != DataMap.end(); ++i)
-    (this->*i->second).Load(SaveFile);
+  for(const datamap::value_type& p : DataMap)
+    (this->*p.second).Load(SaveFile);
 }
 
 template <class scriptmemberptr> void InitMember(script::datamap& DataMap, cchar* Identifier, scriptmemberptr DataMember)
@@ -954,11 +954,11 @@ void levelscript::Combine(levelscript& Script)
   Square.splice(Square.end(), Script.Square);
   Room.splice(Room.end(), Script.Room);
 
-  for(std::list<roomscript>::iterator i1 = Room.begin(); i1 != Room.end(); ++i1)
-    i1->SetBase(GetRoomDefault());
+  for(roomscript& RoomScript : Room)
+    RoomScript.SetBase(GetRoomDefault());
 
-  for(datamap::const_iterator i2 = DataMap.begin(); i2 != DataMap.end(); ++i2)
-    (this->*i2->second).Replace(Script.*i2->second);
+  for(const datamap::value_type& p : DataMap)
+    (this->*p.second).Replace(Script.*p.second);
 }
 
 void levelscript::SetBase(const scriptwithbase* What)
@@ -971,8 +971,8 @@ void levelscript::SetBase(const scriptwithbase* What)
     roomscript* ThisRoomDefault = RoomDefaultHolder.Member;
 
     if(!ThisRoomDefault)
-      for(std::list<roomscript>::iterator i = Room.begin(); i != Room.end(); ++i)
-	i->SetBase(BaseRoomDefault);
+      for(roomscript& RoomScript : Room)
+	RoomScript.SetBase(BaseRoomDefault);
     else
       ThisRoomDefault->SetBase(BaseRoomDefault);
   }
@@ -991,8 +991,8 @@ void levelscript::Load(inputfile& SaveFile)
   const roomscript* RoomDefault = GetRoomDefault();
 
   if(RoomDefault)
-    for(std::list<roomscript>::iterator i = Room.begin(); i != Room.end(); ++i)
-      i->SetBase(RoomDefault);
+    for(roomscript& RoomScript : Room)
+      RoomScript.SetBase(RoomDefault);
 }
 
 dungeonscript::dungeonscript() { }
@@ -1058,10 +1058,10 @@ void dungeonscript::ReadFrom(inputfile& SaveFile)
 
 void dungeonscript::RandomizeLevels()
 {
-  for(std::list<std::pair<interval, levelscript>>::iterator i = RandomLevel.begin(); i != RandomLevel.end(); ++i)
+  for(std::pair<interval, levelscript>& p : RandomLevel)
   {
-    int Index = i->first.Randomize();
-    Level[Index].Combine(i->second);
+    int Index = p.first.Randomize();
+    Level[Index].Combine(p.second);
   }
 
   RandomLevel.clear();
@@ -1081,11 +1081,11 @@ void dungeonscript::Load(inputfile& SaveFile)
 
   if(LevelDefault)
   {
-    for(std::map<int, levelscript>::iterator i1 = Level.begin(); i1 != Level.end(); ++i1)
-      i1->second.SetBase(LevelDefault);
+    for(std::pair<const int, levelscript>& p : Level)
+      p.second.SetBase(LevelDefault);
 
-    for(std::list<std::pair<interval, levelscript>>::iterator i2 = RandomLevel.begin(); i2 != RandomLevel.end(); ++i2)
-      i2->second.SetBase(LevelDefault);
+    for(std::pair<interval, levelscript>& p : RandomLevel)
+      p.second.SetBase(LevelDefault);
   }
 }
 
@@ -1174,8 +1174,8 @@ void gamescript::ReadFrom(inputfile& SaveFile)
 
 void gamescript::RandomizeLevels()
 {
-  for(std::map<int, dungeonscript>::iterator i = Dungeon.begin(); i != Dungeon.end(); ++i)
-    i->second.RandomizeLevels();
+  for(std::pair<const int, dungeonscript>& p : Dungeon)
+    p.second.RandomizeLevels();
 }
 
 void gamescript::Save(outputfile& SaveFile) const

--- a/Main/Source/script.cpp
+++ b/Main/Source/script.cpp
@@ -95,7 +95,7 @@ INST_SCRIPT_MEMBER(squarescript);
 INST_SCRIPT_MEMBER(roomscript);
 INST_SCRIPT_MEMBER(levelscript);
 INST_SCRIPT_MEMBER(contentscript<character>);
-INST_SCRIPT_MEMBER(fearray<contentscript<item> >);
+INST_SCRIPT_MEMBER(fearray<contentscript<item>>);
 INST_SCRIPT_MEMBER(contentscript<glterrain>);
 INST_SCRIPT_MEMBER(contentscript<olterrain>);
 INST_SCRIPT_MEMBER(charactercontentmap);
@@ -483,7 +483,7 @@ character* contentscript<character>::Instantiate(int SpecialFlags) const
   if(GetTeam() != DEFAULT_TEAM)
     Instance->SetTeam(game::GetTeam(GetTeam()));
 
-  const fearray<contentscript<item> >* Inventory = GetInventory();
+  const fearray<contentscript<item>>* Inventory = GetInventory();
 
   if(Inventory)
     Instance->AddToInventory(*Inventory, SpecialFlags);
@@ -567,7 +567,7 @@ item* contentscript<item>::Instantiate(int SpecialFlags) const
   if(GetEnchantment() != 0)
     Instance->SetEnchantment(GetEnchantment());
 
-  const fearray<contentscript<item> >* ItemsInside = GetItemsInside();
+  const fearray<contentscript<item>>* ItemsInside = GetItemsInside();
 
   if(ItemsInside)
     Instance->SetItemsInside(*ItemsInside, SpecialFlags);
@@ -578,7 +578,7 @@ item* contentscript<item>::Instantiate(int SpecialFlags) const
   return Instance;
 }
 
-truth IsValidScript(const fearray<contentscript<item> >* Array)
+truth IsValidScript(const fearray<contentscript<item>>* Array)
 {
   for(uint c = 0; c < Array->Size; ++c)
     if(IsValidScript(&Array->Data[c]))
@@ -631,7 +631,7 @@ olterrain* contentscript<olterrain>::Instantiate(int SpecialFlags) const
   if(Text)
     Instance->SetText(*Text);
 
-  const fearray<contentscript<item> >* ItemsInside = GetItemsInside();
+  const fearray<contentscript<item>>* ItemsInside = GetItemsInside();
 
   if(ItemsInside)
     Instance->SetItemsInside(*ItemsInside, SpecialFlags);
@@ -1058,7 +1058,7 @@ void dungeonscript::ReadFrom(inputfile& SaveFile)
 
 void dungeonscript::RandomizeLevels()
 {
-  for(std::list<std::pair<interval, levelscript> >::iterator i = RandomLevel.begin(); i != RandomLevel.end(); ++i)
+  for(std::list<std::pair<interval, levelscript>>::iterator i = RandomLevel.begin(); i != RandomLevel.end(); ++i)
   {
     int Index = i->first.Randomize();
     Level[Index].Combine(i->second);
@@ -1084,12 +1084,12 @@ void dungeonscript::Load(inputfile& SaveFile)
     for(std::map<int, levelscript>::iterator i1 = Level.begin(); i1 != Level.end(); ++i1)
       i1->second.SetBase(LevelDefault);
 
-    for(std::list<std::pair<interval, levelscript> >::iterator i2 = RandomLevel.begin(); i2 != RandomLevel.end(); ++i2)
+    for(std::list<std::pair<interval, levelscript>>::iterator i2 = RandomLevel.begin(); i2 != RandomLevel.end(); ++i2)
       i2->second.SetBase(LevelDefault);
   }
 }
 
-const std::vector<std::pair<int, int> >& teamscript::GetRelation() const { return Relation; }
+const std::vector<std::pair<int, int>>& teamscript::GetRelation() const { return Relation; }
 
 void teamscript::InitDataMap()
 {
@@ -1131,7 +1131,7 @@ void teamscript::Load(inputfile& SaveFile)
   SaveFile >> Relation;
 }
 
-const std::list<std::pair<int, teamscript> >& gamescript::GetTeam() const { return Team; }
+const std::list<std::pair<int, teamscript>>& gamescript::GetTeam() const { return Team; }
 const std::map<int, dungeonscript>& gamescript::GetDungeon() const { return Dungeon; }
 
 void gamescript::InitDataMap()

--- a/Main/Source/team.cpp
+++ b/Main/Source/team.cpp
@@ -129,8 +129,8 @@ int team::GetEnabledMembers() const
 {
   int Amount = 0;
 
-  for(std::list<character*>::const_iterator i = Member.begin(); i != Member.end(); ++i)
-    if((*i)->IsEnabled())
+  for(character* p : Member)
+    if(p->IsEnabled())
       ++Amount;
 
   return Amount;
@@ -151,16 +151,16 @@ inputfile& operator>>(inputfile& SaveFile, team*& Team)
 
 void team::MoveMembersTo(charactervector& CVector)
 {
-  for(std::list<character*>::iterator i = Member.begin(); i != Member.end(); ++i)
-    if((*i)->IsEnabled())
+  for(character* p : Member)
+    if(p->IsEnabled())
     {
-      if((*i)->GetAction() && (*i)->GetAction()->IsVoluntary())
-	(*i)->GetAction()->Terminate(false);
+      if(p->GetAction() && p->GetAction()->IsVoluntary())
+	p->GetAction()->Terminate(false);
 
-      if(!(*i)->GetAction())
+      if(!p->GetAction())
       {
-	CVector.push_back(*i);
-	(*i)->Remove();
+	CVector.push_back(p);
+	p->Remove();
       }
     }
 }

--- a/Main/Source/worldmap.cpp
+++ b/Main/Source/worldmap.cpp
@@ -24,7 +24,6 @@
 int DirX[8] = { -1, -1, -1, 0, 0, 1, 1, 1 };
 int DirY[8] = { -1, 0, 1, -1, 1, -1, 0, 1 };
 
-worldmap::worldmap() { }
 continent* worldmap::GetContinentUnder(v2 Pos) const
 { return Continent[ContinentBuffer[Pos.X][Pos.Y]]; }
 v2 worldmap::GetEntryPos(ccharacter*, int I) const


### PR DESCRIPTION
These commits slightly improve readability (especially in the case of range-`for`), maybe efficiency in some areas, and of course, make the source code more "modern" and slightly more attractive to C++ developers.

When I have more time I will do some more (drastic) changes, e.g. smart pointers (nobody wants raw `new`/`delete` in their C++ anymore), move semantics, auto, lambdas, etc.

Btw was there some specific reason why `truth` was typedefed to `long`? I can't think of any, and changing it to `bool` made save/bone files incompatible. We could of course still read/write bools as longs from/to files to stay compatible with saves/bones, but is it worth it, what do you think?