### PR TITLE
Fix direction key option

### DIFF
--- a/Main/Include/iconf.h
+++ b/Main/Include/iconf.h
@@ -26,7 +26,7 @@ class ivanconfig
   static truth GetWarnAboutDanger() { return WarnAboutDanger.Value; }
   static truth GetAutoDropLeftOvers() { return AutoDropLeftOvers.Value; }
   static truth GetLookZoom() { return LookZoom.Value; }
-  static truth GetDirectionKeyMap() { return DirectionKeyMap.Value; }
+  static long GetDirectionKeyMap() { return DirectionKeyMap.Value; }
   static truth GetBeNice() { return BeNice.Value; }
 #ifndef __DJGPP__
   static truth GetFullScreenMode() { return FullScreenMode.Value; }


### PR DESCRIPTION
The switch from `long` to `bool` in the `truth` typedef broke this option, so
only the Normal and Alternative keymaps were present. The option now uses a
`long` instead of a `truth` so that all three mappings are available.