### PR TITLE
Don't generate -p directory when installing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = FeLib Main Script Graphics
 EXTRA_DIST = IVAN.dsw FeLib.dsp Main.dsp ivandj.mak ivanmgw.mak LICENSING .customs.emacs
 
 install-data-local:
-	-./mkinstalldirs -p $(localstatedir)/ivan $(localstatedir)/ivan/Bones/
+	-./mkinstalldirs $(localstatedir)/ivan $(localstatedir)/ivan/Bones/
 	-touch $(localstatedir)/ivan/ivan-highscore.scores
 	-chmod 666 $(localstatedir)/ivan/ivan-highscore.scores
 	-chmod -R u=rwx $(localstatedir)/ivan/Bones/

--- a/Makefile.in
+++ b/Makefile.in
@@ -771,7 +771,7 @@ uninstall-am:
 
 
 install-data-local:
-	-./mkinstalldirs -p $(localstatedir)/ivan $(localstatedir)/ivan/Bones/
+	-./mkinstalldirs $(localstatedir)/ivan $(localstatedir)/ivan/Bones/
 	-touch $(localstatedir)/ivan/ivan-highscore.scores
 	-chmod 666 $(localstatedir)/ivan/ivan-highscore.scores
 	-chmod -R u=rwx $(localstatedir)/ivan/Bones/


### PR DESCRIPTION
Fixes #73.

This was caused by `mkinstalldirs` being used as if it was `mkdir`, but in reality `mkinstalldirs` behaves more or less like `mkdir -p`, so the `-p` option was redundant in addition to being handled as a directory name.