### PR TITLE
WIP: Lanterns cause fire

### DIFF
--- a/Main/Include/level.h
+++ b/Main/Include/level.h
@@ -91,6 +91,7 @@ struct explosion
   int RadiusSquare;
   int Size;
   truth HurtNeutrals;
+  truth FireOnly;
 };
 
 struct beamdata
@@ -175,7 +176,7 @@ class level : public area
   room* GetRoom(int) const;
   void SetRoom(int, room*);
   void AddRoom(room*);
-  void Explosion(character*, cfestring&, v2, int, truth = true);
+  void Explosion(character*, cfestring&, v2, int, truth = true, truth = false);
   truth CollectCreatures(charactervector&, character*, truth);
   void ApplyLSquareScript(const squarescript*);
   virtual void Draw(truth) const;

--- a/Main/Include/miscitem.h
+++ b/Main/Include/miscitem.h
@@ -92,6 +92,7 @@ ITEM(lantern, item)
   virtual truth AllowAlphaEverywhere() const { return true; }
   virtual int GetSpecialFlags() const;
   virtual truth IsLanternOnWall() const { return GetSquarePosition() != CENTER; }
+  virtual void Break(character*, int);
  protected:
   virtual int GetClassAnimationFrames() const { return !IsBroken() ? 32 : 1; }
   virtual col16 GetMaterialColorA(int) const;

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -6985,27 +6985,29 @@ void character::GetHitByExplosion(const explosion* Explosion, int Damage)
   if(!IsPet() && Explosion->Terrorist && Explosion->Terrorist->IsPet())
     Explosion->Terrorist->Hostility(this);
 
-  GetTorso()->SpillBlood((8 - Explosion->Size + RAND() % (8 - Explosion->Size)) >> 1);
+  if(!Explosion->FireOnly)
+    GetTorso()->SpillBlood((8 - Explosion->Size + RAND() % (8 - Explosion->Size)) >> 1);
 
   if(DamageDirection == RANDOM_DIR)
     DamageDirection = RAND() & 7;
 
   v2 SpillPos = GetPos() + game::GetMoveVector(DamageDirection);
 
-  if(GetArea()->IsValidPos(SpillPos))
+  if(GetArea()->IsValidPos(SpillPos) && !Explosion->FireOnly)
     GetTorso()->SpillBlood((8 - Explosion->Size + RAND() % (8 - Explosion->Size)) >> 1, SpillPos);
 
   if(IsPlayer())
-    ADD_MESSAGE("You are hit by the explosion!");
+    ADD_MESSAGE("You are %s by the explosion!", Explosion->FireOnly ? "burned" : "hit");
   else if(CanBeSeenByPlayer())
-    ADD_MESSAGE("%s is hit by the explosion.", CHAR_NAME(DEFINITE));
+    ADD_MESSAGE("%s is %s by the explosion.", CHAR_NAME(DEFINITE), Explosion->FireOnly ? "burned" : "hit");
 
   truth WasUnconscious = GetAction() && GetAction()->IsUnconsciousness();
-  ReceiveDamage(Explosion->Terrorist, Damage >> 1, FIRE, ALL, DamageDirection, true, false, false, false);
+  ReceiveDamage(Explosion->Terrorist, Explosion->FireOnly ? Damage : (Damage >> 1), FIRE,
+                ALL, DamageDirection, true, false, false, false);
 
   if(IsEnabled())
   {
-    ReceiveDamage(Explosion->Terrorist, Damage >> 1, PHYSICAL_DAMAGE,
+    ReceiveDamage(Explosion->Terrorist, Explosion->FireOnly ? 0 : (Damage >> 1), PHYSICAL_DAMAGE,
                   ALL, DamageDirection, true, false, false, false);
     CheckDeath(Explosion->DeathMsg, Explosion->Terrorist, !WasUnconscious ? IGNORE_UNCONSCIOUSNESS : 0);
   }

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -6996,21 +6996,34 @@ void character::GetHitByExplosion(const explosion* Explosion, int Damage)
   if(GetArea()->IsValidPos(SpillPos) && !Explosion->FireOnly)
     GetTorso()->SpillBlood((8 - Explosion->Size + RAND() % (8 - Explosion->Size)) >> 1, SpillPos);
 
-  if(IsPlayer())
-    ADD_MESSAGE("You are %s by the explosion!", Explosion->FireOnly ? "burned" : "hit");
-  else if(CanBeSeenByPlayer())
-    ADD_MESSAGE("%s is %s by the explosion.", CHAR_NAME(DEFINITE), Explosion->FireOnly ? "burned" : "hit");
-
   truth WasUnconscious = GetAction() && GetAction()->IsUnconsciousness();
-  ReceiveDamage(Explosion->Terrorist, Explosion->FireOnly ? Damage : (Damage >> 1), FIRE,
-                ALL, DamageDirection, true, false, false, false);
+  truth Burned = ReceiveDamage(Explosion->Terrorist, Explosion->FireOnly ? Damage : (Damage >> 1),
+                               FIRE, ALL, DamageDirection, true, false, false, false);
+  truth Pummeled = ReceiveDamage(Explosion->Terrorist, Explosion->FireOnly ? 0 : (Damage >> 1),
+                                 PHYSICAL_DAMAGE, ALL, DamageDirection, true, false, false, false);
+
+  festring Msg;
+  if(IsPlayer())
+    Msg << "You are ";
+  else
+    Msg << CHAR_NAME(DEFINITE) << " is ";
+
+  if (Burned && Pummeled)
+    Msg << "blasted ";
+  else if (Burned)
+    Msg << "burned ";
+  else if (Pummeled)
+    Msg << "pummeled ";
+  else
+    Msg << "unharmed ";
+
+  Msg << "by the " << (Explosion->FireOnly ? "fireball" : "explosion") << "!";
+
+  if(IsPlayer() || CanBeSeenByPlayer())
+    ADD_MESSAGE(Msg.CStr());
 
   if(IsEnabled())
-  {
-    ReceiveDamage(Explosion->Terrorist, Explosion->FireOnly ? 0 : (Damage >> 1), PHYSICAL_DAMAGE,
-                  ALL, DamageDirection, true, false, false, false);
     CheckDeath(Explosion->DeathMsg, Explosion->Terrorist, !WasUnconscious ? IGNORE_UNCONSCIOUSNESS : 0);
-  }
 }
 
 void character::SortAllItems(const sortdata& SortData)

--- a/Main/Source/level.cpp
+++ b/Main/Source/level.cpp
@@ -867,7 +867,7 @@ room* level::GetRoom(int I) const
   return Room[I];
 }
 
-void level::Explosion(character* Terrorist, cfestring& DeathMsg, v2 Pos, int Strength, truth HurtNeutrals)
+void level::Explosion(character* Terrorist, cfestring& DeathMsg, v2 Pos, int Strength, truth HurtNeutrals, truth FireOnly)
 {
   static int StrengthLimit[6] = { 500, 250, 100, 50, 25, 10 };
   uint c;
@@ -890,6 +890,7 @@ void level::Explosion(character* Terrorist, cfestring& DeathMsg, v2 Pos, int Str
   Exp->RadiusSquare = (8 - Size) * (8 - Size);
   Exp->Size = Size;
   Exp->HurtNeutrals = HurtNeutrals;
+  Exp->FireOnly = FireOnly;
   ExplosionQueue.push_back(Exp);
 
   if(ExplosionQueue.size() == 1)

--- a/Main/Source/lsquare.cpp
+++ b/Main/Source/lsquare.cpp
@@ -1524,7 +1524,7 @@ truth lsquare::FireBall(const beamdata& Beam)
     if(CanBeSeenByPlayer(true))
       ADD_MESSAGE("A magical explosion is triggered!");
 
-    GetLevel()->Explosion(Beam.Owner, Beam.DeathMsg, Pos, 75 + RAND() % 25 - RAND() % 25);
+    GetLevel()->Explosion(Beam.Owner, Beam.DeathMsg, Pos, 75 + RAND() % 25 - RAND() % 25, true, true);
     return true;
   }
 

--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -1594,6 +1594,19 @@ void lantern::Break(character* Breaker, int Dir)
 
   if(Broken->Exists()) {
     lsquare* Square = Broken->GetLSquareUnder();
+
+    festring DeathMsg = CONST_S("killed by the fire from ");
+    AddName(DeathMsg, INDEFINITE);
+
+    if(Breaker)
+      DeathMsg << " caused @bk";
+
+    if(Square->CanBeSeenByPlayer(true))
+      ADD_MESSAGE("Flames erupt from %s!", GetExtendedDescription().CStr());
+
+    Square->GetLevel()->Explosion(Breaker, DeathMsg, Square->GetPos(), 5, true, true);
+
+    /*
     stack* Stack = Square->GetStack();
 
     for(stackiterator i = Stack->GetBottom(); i.HasItem(); ++i)
@@ -1612,6 +1625,7 @@ void lantern::Break(character* Breaker, int Dir)
       game::AskForKeyPress(Square->GetCharacter()->GetDescription(DEFINITE));
       Square->GetCharacter()->ReceiveDamage(Breaker, 100, FIRE, ALL, Dir, true, false, false, false);
     }
+    */
   }
 
   if(PLAYER->Equips(Broken))

--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -1604,27 +1604,6 @@ void lantern::Break(character* Breaker, int Dir)
       ADD_MESSAGE("Flames erupt from %s!", GetExtendedDescription().CStr());
 
     Square->GetLevel()->Explosion(Breaker, DeathMsg, Square->GetPos(), 5, true, true);
-
-    /*
-    stack* Stack = Square->GetStack();
-
-    for(stackiterator i = Stack->GetBottom(); i.HasItem(); ++i)
-    {
-      item* Item = *i;
-      i->ReceiveDamage(Breaker, 100, FIRE, Dir);
-    }
-    game::AskForKeyPress("LANTERN: terrain exists?");
-    if(Square->GetOLTerrain()) {
-      game::AskForKeyPress("LANTERN: burning the terrain");
-      Square->GetOLTerrain()->ReceiveDamage(Breaker, 100, FIRE);
-    }
-    game::AskForKeyPress("LANTERN: character in square?");
-    if(Square->GetCharacter()) {
-      game::AskForKeyPress("LANTERN: burning the character");
-      game::AskForKeyPress(Square->GetCharacter()->GetDescription(DEFINITE));
-      Square->GetCharacter()->ReceiveDamage(Breaker, 100, FIRE, ALL, Dir, true, false, false, false);
-    }
-    */
   }
 
   if(PLAYER->Equips(Broken))

--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -1588,7 +1588,6 @@ void lantern::Break(character* Breaker, int Dir)
   DonateFluidsTo(Broken);
   DonateIDTo(Broken);
   DonateSlotTo(Broken);
-  SendToHell();
 
 
   if(Broken->Exists()) {
@@ -1605,6 +1604,8 @@ void lantern::Break(character* Breaker, int Dir)
 
     Square->GetLevel()->Explosion(Breaker, DeathMsg, Square->GetPos(), 5, true, true);
   }
+
+  SendToHell();
 
   if(PLAYER->Equips(Broken))
     game::AskForKeyPress(CONST_S("Equipment broken! [press any key to continue]"));

--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -1585,7 +1585,6 @@ void lantern::Break(character* Breaker, int Dir)
 
   item* Broken = GetProtoType()->Clone(this);
   Broken->SetConfig(GetConfig() | BROKEN);
-  Broken->SetSize(Broken->GetSize() >> 1);
   DonateFluidsTo(Broken);
   DonateIDTo(Broken);
   DonateSlotTo(Broken);


### PR DESCRIPTION
https://github.com/Attnam/ivan/issues/17

This makes lanterns deal fire damage to objects, terrain, and creatures
present in the square the break in.

There was a seg fault throwing a lantern at genetrix so I threw in lots
of debug printing to make sure this functions. Also, 100 fire damage is
almost certainly too much. Move it to a variable on Lantern later.

Perhaps redo this to use an explosion and change explosions to have
option to do only FIRE damage?