### PR TITLE
WIP: Add titanium int 25 in adamant material chain

### DIFF
--- a/Main/Include/confdef.h
+++ b/Main/Include/confdef.h
@@ -85,6 +85,7 @@
 #define DARK_GRASS (SOLID_ID + 64)
 #define LEAD (SOLID_ID + 65)
 #define BLACK_GRANITE (SOLID_ID + 66)
+#define TITANIUM (SOLID_ID + 67)
 
 #define ORGANIC_ID (2 << 12)
 

--- a/Script/define.dat
+++ b/Script/define.dat
@@ -313,6 +313,7 @@
 #define LEAD (SOLID_ID + 65)
 #define BLACK_GRANITE (SOLID_ID + 66)
 #define BLACK_LEATHER (SOLID_ID + 67)
+#define TITANIUM (SOLID_ID + 67)
 
 #define ORGANIC_ID (4096 * 2)
 

--- a/Script/material.dat
+++ b/Script/material.dat
@@ -360,6 +360,20 @@ solid
     InteractionFlags = Base&~CAN_DISSOLVE;
   }
 
+  Config TITANIUM;
+  {
+    StrengthValue = 200;
+    ConsumeType = CT_METAL;
+    Density = 4500;
+    Color = rgb16(190, 190, 190);
+    PriceModifier = 1000;
+    NameStem = "titanium";
+    AttachedGod = LORICATUS;
+    HardenedMaterial = ADAMANT;
+    IntelligenceRequirement = 25;
+    CommonFlags = Base|IS_METAL|IS_VALUABLE;
+  }
+
   Config BRONZE;
   {
     StrengthValue = 80;
@@ -1041,7 +1055,7 @@ solid
     NameStem = "lead";
     Flexibility = 2;
     AttachedGod = LORICATUS;
-    HardenedMaterial = ADAMANT;
+    HardenedMaterial = TITANIUM;
     IntelligenceRequirement = 7;
     CommonFlags = Base;
     CategoryFlags = Base|IS_METAL|IS_GOLEM_MATERIAL;
@@ -2322,7 +2336,7 @@ ironalloy /* metals that rust */
     NameStem = "meteoric steel";
     AttachedGod = LORICATUS;
     RustModifier = 50;
-    HardenedMaterial = ADAMANT;
+    HardenedMaterial = TITANIUM;
     IntelligenceRequirement = 15;
     CommonFlags = Base|IS_VALUABLE;
   }


### PR DESCRIPTION
`Density` is real, but `Strength` and `PriceModifier` are just guesses.

TODO:
- [ ] Add `TITANIUM` as config option for various metal items
- [ ] Review `PriceModifier` to make sure it's reasonable
  - In particular, prices are calculated proportional to `PriceModifier * Weight` so the lower density may undervalue it
  - More likely, it's too high; check other `IntelligenceRequirement = 25` materials for balance
- [ ] Review `Strength` to make sure it's reasonable
  - Make sure it's in line with other materials at this level of `IntelligenceRequirement`
- [ ] Add another metal with `IntelligenceRequirement = 30` (?)