### PR TITLE
Experience for buying and selling was WAY off

### DIFF
--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -8145,7 +8145,7 @@ void characterdatabase::PostProcess()
 
 void character::EditDealExperience(long Price)
 {
-  EditExperience(CHARISMA, sqrt(Price) / 5, 1 << 9);
+  EditExperience(CHARISMA, sqrt(Price) * 10, 15000);
 }
 
 void character::PrintBeginLeprosyMessage() const


### PR DESCRIPTION
This table shows the number of transactions required to raise charisma
by 1 point. With the old system, it would take ~1500 transactions
costing 1000 gp to go from Cha 10 to 11.

| Charisma | 10 GP | 50 GP | 200 GP | 400 GP |
|----------|-------|-------|--------|--------|
| 10->11   | 10.5  | 4.7   | 2.4    | 1.7    |
| 15->16   | N/A   | 16.1  | 3.6    | 2.2    |
| 20->21   | N/A   | N/A   | 8.0    | 3.3    |
| 25->26   | N/A   | N/A   | N/A    | 6.7    |
| Max      | 13    | 17    | 24     | 30     |