### PR TITLE
Fix buffer overflow bug

### DIFF
--- a/Main/Source/gear.cpp
+++ b/Main/Source/gear.cpp
@@ -149,10 +149,12 @@ truth pickaxe::Apply(character* User)
   }
 
   int Dir = game::DirectionQuestion(CONST_S("What direction do you want to dig? [press a direction key]"), false);
+  if(Dir == DIR_ERROR)
+    return false;
 
   v2 Temp = game::GetMoveVector(Dir);
   v2 ToBeDug = User->GetPos() + Temp;
-  if(Dir == DIR_ERROR || !GetArea()->IsValidPos(ToBeDug))
+  if(!GetArea()->IsValidPos(ToBeDug))
     return false;
 
   lsquare* Square = GetNearLSquare(ToBeDug);


### PR DESCRIPTION
This happened because Dir was passed to GetMoveVector without
checking for DIR_ERROR first.