### PR TITLE
Optimize BlitDBToScreen

### DIFF
--- a/FeLib/Source/graphics.cpp
+++ b/FeLib/Source/graphics.cpp
@@ -261,7 +261,16 @@ void graphics::BlitDBToScreen()
   SDL_UpdateRect(Screen, 0, 0, Res.X, Res.Y);
 #else
   packcol16* SrcPtr = DoubleBuffer->GetImage()[0];
-  SDL_UpdateTexture(Texture, NULL, SrcPtr, Res.X * sizeof(packcol16));
+  void* DestPtr;
+  int Pitch;
+
+  if (SDL_LockTexture(Texture, NULL, &DestPtr, &Pitch) < 0)
+    ABORT("Can't lock texture");
+
+  memcpy(DestPtr, SrcPtr, Res.Y * Pitch);
+
+  SDL_UnlockTexture(Texture);
+
   SDL_RenderClear(Renderer);
   SDL_RenderCopy(Renderer, Texture, NULL, NULL);
   SDL_RenderPresent(Renderer);


### PR DESCRIPTION
From the [SDL2 wiki](https://wiki.libsdl.org/SDL_UpdateTexture):

> [`SDL_UpdateTexture`] is a fairly slow function, intended for use with static textures that do not change often.
>
> If the texture is intended to be updated often, it is preferred to create the texture as streaming and use the locking functions [...].

Since the texture passed to `SDL_UpdateTexture` is used as the "framebuffer" and hence updated every frame, I think it counts as being "updated often".

Some profiling shows the time usage going from 8.9% for `SDL_UpdateTexture` down to 7.1% for this new code.