### PR TITLE
Auto-detect dungeon data files

### DIFF
--- a/FeLib/Include/save.h
+++ b/FeLib/Include/save.h
@@ -93,6 +93,8 @@ class inputfile
   truth lastWordWasString;
 };
 
+std::vector<festring> ListFiles(festring, cfestring&);
+
 /* Reads a binary form variable of type type and returns it.
  * An inputfile template member function would be far more elegant,
  * but VC doesn't seem to understand it. */

--- a/Main/Source/database.cpp
+++ b/Main/Source/database.cpp
@@ -82,9 +82,13 @@ template <class type> void databasecreator<type>::ReadFrom(inputfile& SaveFile)
         Word = inFile->ReadWord();
         if (inFile->ReadWord() != ";")
           ABORT("Invalid terminator at line %ld!", inFile->TellLine());
-        inputfile *incf = new inputfile(game::GetDataDir()+"Script/"+Word, &game::GetGlobalValueMap());
-        infStack.push(inFile);
-        inFile = incf;
+
+        for(cfestring& FileName : ListFiles(game::GetDataDir() + "Script/" + Word, ".dat"))
+        {
+          inputfile *incf = new inputfile(FileName, &game::GetGlobalValueMap());
+          infStack.push(inFile);
+          inFile = incf;
+        }
         continue;
       }
       if (Word == "Message")

--- a/Main/Source/script.cpp
+++ b/Main/Source/script.cpp
@@ -1181,8 +1181,12 @@ void gamescript::ReadFrom(inputfile &SaveFile)
       Word = SaveFile.ReadWord();
       if (SaveFile.ReadWord() != ";")
         ABORT("Invalid terminator at line %ld!", SaveFile.TellLine());
-      inputfile incf(game::GetDataDir()+"Script/"+Word, &game::GetGlobalValueMap());
-      ReadFrom(incf);
+
+      for(cfestring& FileName : ListFiles(game::GetDataDir() + "Script/" + Word, ".dat"))
+      {
+        inputfile incf(FileName, &game::GetGlobalValueMap());
+        ReadFrom(incf);
+      }
       continue;
     }
     if(Word == "Message")

--- a/Script/dungeon.dat
+++ b/Script/dungeon.dat
@@ -95,7 +95,4 @@ Team BETRAYED_TEAM;
   KillEvilness = 10;
 }
 
-Include "dungeons/Attnam.dat";
-Include "dungeons/GloomyCaves.dat";
-Include "dungeons/NewAttnam.dat";
-Include "dungeons/UnderwaterTunnel.dat";
+Include "dungeons/";


### PR DESCRIPTION
Removes the need to specify each dungeon data file separately in `dungeon.dat`.

Haven't tested on Windows but should work.