### PR TITLE
WTerrain data abstraction to data files

### DIFF
--- a/Main/Include/wterra.h
+++ b/Main/Include/wterra.h
@@ -31,6 +31,8 @@ struct wterraindatabase : public databasebase
   void PostProcess() { }
   truth IsAbstract;
   v2 BitmapPos;
+  festring NameStem;
+  truth UsesLongArticle;
 };
 
 class wterrain
@@ -47,10 +49,10 @@ class wterrain
   festring GetName(int) const;
   truth IsAnimated() const { return AnimationFrames > 1; }
   void SetAnimationFrames(int What) { AnimationFrames = What; }
-  virtual cchar* GetNameStem() const = 0;
  protected:
   virtual truth UsesLongArticle() const { return false; }
   virtual v2 GetBitmapPos(int) const = 0;
+  virtual cfestring& GetNameStem() const = 0;
   wsquare* WSquareUnder;
   int AnimationFrames;
   void Initialize(int, int);
@@ -62,6 +64,7 @@ struct gwterraindatabase : public wterraindatabase
   typedef gwterrainprototype prototype;
   void InitDefaults(const prototype*, int);
   const prototype* ProtoType;
+  int Priority;
 };
 
 class gwterrainprototype
@@ -78,6 +81,7 @@ class gwterrainprototype
   const gwterraindatabase* ChooseBaseForConfig(gwterraindatabase** TempConfig, int, int) { return *TempConfig; }
   const gwterraindatabase*const* GetConfigData() const { return ConfigData; }
   int GetConfigSize() const { return ConfigSize; }
+  virtual int GetPriority() const { return 0; }
  private:
   int Index;
   const gwterrainprototype* Base;
@@ -101,15 +105,17 @@ class gwterrain : public wterrain, public gterrain
   DATA_BASE_VALUE(const prototype*, ProtoType);
   DATA_BASE_VALUE(int, Config);
   void Draw(blitdata&) const;
-  virtual int GetPriority() const = 0;
   virtual int GetEntryDifficulty() const { return 10; }
   void CalculateNeighbourBitmapPoses();
   virtual int GetWalkability() const;
+  DATA_BASE_TRUTH(UsesLongArticle);
+  DATA_BASE_VALUE(int, Priority);
  protected:
   std::pair<v2, int> Neighbour[8];
   virtual void InstallDataBase(int);
   virtual const prototype* FindProtoType() const { return &ProtoType; }
   virtual v2 GetBitmapPos(int) const;
+  virtual cfestring& GetNameStem() const;
   static const prototype ProtoType;
   const database* DataBase;
 };
@@ -119,6 +125,8 @@ struct owterraindatabase : public wterraindatabase
   typedef owterrainprototype prototype;
   void InitDefaults(const prototype*, int);
   const prototype* ProtoType;
+  int AttachedDungeon;
+  int AttachedArea;
 };
 
 class owterrainprototype
@@ -135,6 +143,8 @@ class owterrainprototype
   const owterraindatabase* ChooseBaseForConfig(owterraindatabase** TempConfig, int, int) { return *TempConfig; }
   const owterraindatabase*const* GetConfigData() const { return ConfigData; }
   int GetConfigSize() const { return ConfigSize; }
+  virtual int GetAttachedDungeon() const { return 0; }
+  virtual int GetAttachedArea() const { return 0; }
  private:
   int Index;
   const owterrainprototype* Base;
@@ -155,16 +165,18 @@ class owterrain : public wterrain, public oterrain
   virtual void Load(inputfile&);
   void Draw(blitdata&) const;
   int GetType() const { return GetProtoType()->GetIndex(); }
-  virtual int GetAttachedDungeon() const { return 0; }
-  virtual int GetAttachedArea() const { return 0; }
   virtual int GetAttachedEntry() const;
   virtual truth Enter(truth) const;
   virtual int GetWalkability() const;
   const database* GetDataBase() const { return DataBase; }
   DATA_BASE_VALUE(const prototype*, ProtoType);
   DATA_BASE_VALUE(int, Config);
+  DATA_BASE_TRUTH(UsesLongArticle);
+  DATA_BASE_VALUE(int, AttachedDungeon);
+  DATA_BASE_VALUE(int, AttachedArea);
  protected:
   virtual v2 GetBitmapPos(int) const;
+  virtual cfestring& GetNameStem() const;
   virtual void InstallDataBase(int);
   virtual const prototype* FindProtoType() const { return &ProtoType; }
   static const prototype ProtoType;

--- a/Main/Include/wterras.h
+++ b/Main/Include/wterras.h
@@ -19,10 +19,7 @@ GWTERRAIN(ocean, gwterrain)
 {
  public:
   ocean() { SetAnimationFrames(32); }
-  virtual cchar* GetNameStem() const;
-  virtual truth UsesLongArticle() const { return true; }
   virtual v2 GetBitmapPos(int) const;
-  virtual int GetPriority() const { return 10; }
   virtual cchar* SurviveMessage() const;
   virtual cchar* MonsterSurviveMessage() const;
   virtual cchar* DeathMessage() const;
@@ -34,89 +31,50 @@ GWTERRAIN(ocean, gwterrain)
 
 GWTERRAIN(glacier, gwterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetPriority() const { return 90; }
 };
 
 GWTERRAIN(desert, gwterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetPriority() const { return 20; }
 };
 
 GWTERRAIN(snow, gwterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetPriority() const { return 80; }
 };
 
 GWTERRAIN(jungle, gwterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetPriority() const { return 50; }
 };
 
 GWTERRAIN(leafyforest, gwterrain)
 {
-  virtual cchar* GetNameStem() const;
-  virtual int GetPriority() const { return 60; }
 };
 
 GWTERRAIN(evergreenforest, gwterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual truth UsesLongArticle() const { return true; }
-  virtual int GetPriority() const { return 70; }
 };
 
 GWTERRAIN(steppe, gwterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetPriority() const { return 30; }
 };
 
 OWTERRAIN(attnam, owterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetAttachedDungeon() const;
 };
 
 OWTERRAIN(elpuricave, owterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetAttachedDungeon() const;
 };
 
 OWTERRAIN(newattnam, owterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetAttachedDungeon() const;
 };
 
 OWTERRAIN(underwatertunnel, owterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetAttachedDungeon() const;
-  virtual truth UsesLongArticle() const { return true; }
 };
 
 OWTERRAIN(underwatertunnelexit, owterrain)
 {
- public:
-  virtual cchar* GetNameStem() const;
-  virtual int GetAttachedDungeon() const;
-  virtual truth UsesLongArticle() const { return true; }
-  virtual int GetAttachedArea() const { return 2; }
 };
 
 #endif

--- a/Main/Source/database.cpp
+++ b/Main/Source/database.cpp
@@ -679,18 +679,23 @@ void databasecreator<type>::CreateWTerrainDataBaseMemberMap()
   databasemembermap& Map = GetDataBaseMemberMap();
   ADD_MEMBER(BitmapPos);
   ADD_MEMBER(IsAbstract);
+  ADD_MEMBER(NameStem);
+  ADD_MEMBER(UsesLongArticle);
 }
 
 template<> void databasecreator<gwterrain>::CreateDataBaseMemberMap()
 {
   CreateWTerrainDataBaseMemberMap();
   databasemembermap& Map = GetDataBaseMemberMap();
+  ADD_MEMBER(Priority);
 }
 
 template<> void databasecreator<owterrain>::CreateDataBaseMemberMap()
 {
   CreateWTerrainDataBaseMemberMap();
   databasemembermap& Map = GetDataBaseMemberMap();
+  ADD_MEMBER(AttachedDungeon);
+  ADD_MEMBER(AttachedArea);
 }
 
 template<> void databasecreator<material>::CreateDataBaseMemberMap()

--- a/Main/Source/wterra.cpp
+++ b/Main/Source/wterra.cpp
@@ -217,3 +217,13 @@ v2 owterrain::GetBitmapPos(int) const
 {
   return DataBase->BitmapPos;
 }
+
+cfestring& gwterrain::GetNameStem() const
+{
+  return DataBase->NameStem;
+}
+
+cfestring& owterrain::GetNameStem() const
+{
+  return DataBase->NameStem;
+}

--- a/Main/Source/wterras.cpp
+++ b/Main/Source/wterras.cpp
@@ -12,7 +12,6 @@
 
 /* Compiled through wmapset.cpp */
 
-cchar* ocean::GetNameStem() const { return "ocean"; }
 v2 ocean::GetBitmapPos(int Frame) const
 { return v2(48 + ((Frame << 3)&~8), 48); }
 cchar* ocean::SurviveMessage() const
@@ -22,41 +21,5 @@ cchar* ocean::MonsterSurviveMessage() const
 cchar* ocean::DeathMessage() const { return "you drown"; }
 cchar* ocean::MonsterDeathVerb() const { return "drowns"; }
 cchar* ocean::ScoreEntry() const { return "drowned"; }
-
-cchar* glacier::GetNameStem() const { return "glacier"; }
-
-cchar* desert::GetNameStem() const { return "desert"; }
-
-cchar* snow::GetNameStem() const { return "tundra"; }
-
-cchar* jungle::GetNameStem() const { return "jungle"; }
-
-cchar* leafyforest::GetNameStem() const { return "leafy forest"; }
-
-cchar* evergreenforest::GetNameStem() const
-{ return "evergreen forest"; }
-
-cchar* steppe::GetNameStem() const { return "steppe"; }
-
-cchar* attnam::GetNameStem() const
-{ return "migthy cathedral reaching the clouds"; }
-int attnam::GetAttachedDungeon() const { return ATTNAM; }
-
-cchar* elpuricave::GetNameStem() const
-{ return "hideous cave entry radiating pure evil"; }
-int elpuricave::GetAttachedDungeon() const { return ELPURI_CAVE; }
-
-cchar* newattnam::GetNameStem() const { return "primitive village"; }
-int newattnam::GetAttachedDungeon() const { return NEW_ATTNAM; }
-
-cchar* underwatertunnel::GetNameStem() const
-{ return "entrance to an underwater tunnel"; }
-int underwatertunnel::GetAttachedDungeon() const
-{ return UNDER_WATER_TUNNEL; }
-
-cchar* underwatertunnelexit::GetNameStem() const
-{ return "exit from an underwater tunnel"; }
-int underwatertunnelexit::GetAttachedDungeon() const
-{ return UNDER_WATER_TUNNEL; }
 
 int ocean::GetWalkability() const { return ANY_MOVE&~WALK; }

--- a/Script/gwterra.dat
+++ b/Script/gwterra.dat
@@ -26,45 +26,65 @@
 gwterrain
 {
   /* Obligatory: BitmapPos */
+  NameStem = "";
   IsAbstract = true; /* This is false by default and does not inherit! */
+  UsesLongArticle = false;
+  Priority = 50;
 }
 
 ocean
 {
-/*  BitmapPos overridden in wterras.cpp = 0, 48;*/
+  /* BitmapPos overridden in wterras.cpp = 0, 48; */
+  NameStem = "ocean";
+  UsesLongArticle = true;
+  Priority = 10;
 }
 
 glacier
 {
   BitmapPos = 16, 16;
+  NameStem = "glacier";
+  Priority = 90;
 }
 
 desert
 {
   BitmapPos = 64, 16;
+  NameStem = "desert";
+  Priority = 20;
 }
 
 snow
 {
   BitmapPos = 112, 16;
+  NameStem = "tundra";
+  Priority = 80;
 }
 
 jungle
 {
   BitmapPos = 208, 16;
+  NameStem = "jungle";
+  Priority = 50;
 }
 
 leafyforest
 {
   BitmapPos = 304, 16;
+  NameStem = "leafy forest";
+  Priority = 60;
 }
 
 evergreenforest
 {
   BitmapPos = 352, 16;
+  NameStem = "evergreen forest";
+  Priority = 70;
 }
 
 steppe
 {
   BitmapPos = 160, 16;
+  NameStem = "steppe";
+  Priority = 30;
 }

--- a/Script/owterra.dat
+++ b/Script/owterra.dat
@@ -26,30 +26,49 @@
 owterrain
 {
   /* Obligatory: BitmapPos */
+  NameStem = "";
   IsAbstract = true; /* This is false by default and does not inherit! */
+  UsesLongArticle = false;
+  AttachedArea = 0;
 }
 
 attnam
 {
   BitmapPos = 0, 48;
+  NameStem = "mighty cathedral reaching the clouds";
+  UsesLongArticle = false;
+  AttachedDungeon = ATTNAM;
 }
 
 elpuricave
 {
   BitmapPos = 16, 48;
+  NameStem = "hideous cave entry radiating pure evil";
+  UsesLongArticle = false;
+  AttachedDungeon = ELPURI_CAVE;
 }
 
 newattnam
 {
   BitmapPos = 16, 64;
+  NameStem = "primitive village";
+  UsesLongArticle = false;
+  AttachedDungeon = NEW_ATTNAM;
 }
 
 underwatertunnel
 {
   BitmapPos = 32, 64;
+  NameStem = "entrance to an underwater tunnel";
+  UsesLongArticle = true;
+  AttachedDungeon = UNDER_WATER_TUNNEL;
 }
 
 underwatertunnelexit
 {
   BitmapPos = 32, 64;
+  NameStem = "exit from an underwater tunnel";
+  UsesLongArticle = true;
+  AttachedDungeon = UNDER_WATER_TUNNEL;
+  AttachedArea = 2; /*underwater tunnel level 3*/
 }


### PR DESCRIPTION
`NameStem` and `UsesLongArticle` have been put into gwterra.dat and owterra.dat
`AttachedDungeon` and `AttachedArea` appears in owterra.dat
`Priority` appears in gwterra.dat

Note that changing values like `Priority` are quite likely to radically break the game.