### PR TITLE
Fix for communist::BeTalkedTo

### DIFF
--- a/Main/Source/human.cpp
+++ b/Main/Source/human.cpp
@@ -831,8 +831,13 @@ void communist::BeTalkedTo()
                 CHAR_NAME(UNARTICLED), PLAYER->GetAssignedName().CStr());
 
     for(character* Char : GetTeam()->GetMember())
+    {
       if(Char != this)
         Char->ChangeTeam(PLAYER->GetTeam());
+      
+      if(GetTeam()->GetMembers() == 1) // Only Ivan left in Party
+        break;
+    }
 
     ChangeTeam(PLAYER->GetTeam());
   }


### PR DESCRIPTION
Size of GetTeam()->GetMember() diminished to zero during the for-loop causing a seg-fault

Fixes #119