### PR TITLE
Attribute penalties to burnt limbs have now been scaled back.

### DIFF
--- a/Main/Source/bodypart.cpp
+++ b/Main/Source/bodypart.cpp
@@ -3740,7 +3740,7 @@ int bodypart::CalculateBurnAttributePenalty(int Attribute) const
   if(MainMaterial)
   {
     BurnLevel = MainMaterial->GetBurnLevel();
-    DoubleAttribute *= 1. * (4 - BurnLevel) / 4;
+    DoubleAttribute *= (1. - BurnLevel * 0.05);
   }
 
   return BurnLevel ? Min(Attribute - int(DoubleAttribute), Attribute - 1) : 0;


### PR DESCRIPTION
Now penalised by 5, 10 and 15 % for slightly, moderately and heavily burnt arms and legs.
Used to be 25, 50 and 75 %, which was too excessive.