### PR TITLE
Nerf the perma stat gain from blink dogs and floating eyes a bit

### DIFF
--- a/Script/material.dat
+++ b/Script/material.dat
@@ -2137,6 +2137,7 @@ flesh
     Density = 1000;
     Effect = EFFECT_ESP;
     AttachedGod = LEGIFER;
+    EffectStrength = 50;
     PriceModifier = 120;
     CommonFlags = Base|IS_VALUABLE;
     InteractionFlags = Base|EFFECT_IS_GOOD;
@@ -2203,6 +2204,7 @@ flesh
     NameStem = "blink dog flesh";
     AttachedGod = MORTIFER;
     Effect = EFFECT_TELEPORT_CONTROL;
+    EffectStrength = 15;
     PriceModifier = 120;
     CommonFlags = Base|IS_VALUABLE;
   }


### PR DESCRIPTION
Eat 15 blink dogs instead of three.
Eat fvey floating eyes instead of three.

Fixes #162.