### PR TITLE
Fixing priestess's replies after liberation

### DIFF
--- a/Main/Source/human.cpp
+++ b/Main/Source/human.cpp
@@ -948,7 +948,14 @@ void priest::BeTalkedTo()
                   "for that but I need %ldgp for the ritual materials first.\"", Price);
   }
 
-  humanoid::BeTalkedTo();
+  static long Said;
+
+  if(GetConfig() != SILVA)
+    humanoid::BeTalkedTo();
+  else if(!game::TweraifIsFree())
+    ProcessAndAddMessage(GetFriendlyReplies()[RandomizeReply(Said, 4)]);
+  else
+    ProcessAndAddMessage(GetFriendlyReplies()[4 + RandomizeReply(Said, 3)]);
 }
 
 void skeleton::BeTalkedTo()
@@ -4335,18 +4342,6 @@ truth humanoid::CanConsume(material* Material) const
 }
 
 void femaleslave::BeTalkedTo()
-{
-  static long Said;
-
-  if(GetConfig() != NEW_ATTNAM || GetRelation(PLAYER) == HOSTILE)
-    humanoid::BeTalkedTo();
-  else if(!game::TweraifIsFree())
-    ProcessAndAddMessage(GetFriendlyReplies()[RandomizeReply(Said, 4)]);
-  else
-    ProcessAndAddMessage(GetFriendlyReplies()[4 + RandomizeReply(Said, 3)]);
-}
-
-void priestess::BeTalkedTo()
 {
   static long Said;
 


### PR DESCRIPTION
Tested this time.

Not sure why the "Files changed" is only showing 1. Must be a GitHub bug since the original commit was already merged in and later reverted. After this is merged need to make sure `Script/char.dat` is up to date with all of her replies