### PR TITLE
Travis continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: required
+dist: trusty
+
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+os:
+  - linux
+  - osx
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libsdl2-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl2; fi
+
+script:
+  - mkdir build
+  - cd build
+  - cmake -G "Unix Makefiles" -DCMAKE_CXX_FLAGS=$CXXFLAGS ..
+  - make
+  - make igor
+  - make mihail
+  - sudo make install
+
+env:
+  matrix:
+    - CXXFLAGS=""
+    - CXXFLAGS="-DWIZARD"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12.2)
 
-project(ivan CXX)
+project(ivan CXX C)
 set(PROJECT_VERSION 0.50.7)
 
 set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
This adds automated builds using [Travis](https://travis-ci.org). The builds are done on all pushes and pull requests. Travis will test that the code compiles with all 8 combinations of Linux/Mac,  clang/gcc, and wizard mode on/off.

Admin rights are required to enable Travis CI for this repository. Just login to Travis and go to https://travis-ci.org/profile/Attnam and flick the switch.