### PR TITLE
Use -Werror in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 script:
   - mkdir build
   - cd build
-  - cmake -G "Unix Makefiles" -DCMAKE_CXX_FLAGS=$CXXFLAGS ..
+  - cmake -G "Unix Makefiles" -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" ..
   - make
   - make igor
   - make mihail
@@ -28,5 +28,5 @@ script:
 
 env:
   matrix:
-    - CXXFLAGS=""
-    - CXXFLAGS="-DWIZARD"
+    - CXXFLAGS=
+    - CXXFLAGS=-DWIZARD

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 script:
   - mkdir build
   - cd build
-  - cmake -G "Unix Makefiles" -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" ..
+  - cmake -G "Unix Makefiles" -DCMAKE_CXX_FLAGS="-Werror -Wno-format-security $CXXFLAGS" ..
   - make
   - make igor
   - make mihail

--- a/audio/audio_stack.cpp
+++ b/audio/audio_stack.cpp
@@ -88,7 +88,7 @@ uint8_t STACK_PushData(STACK_t* stack, void* data)
         return STACK_Len(stack);
     }
 
-    return STACK_OVERFLOW;
+    return 0;
 }
 
 uint8_t STACK_Len(STACK_t* stack)


### PR DESCRIPTION
This promotes all compile warnings to errors, so that pull requests that cause warnings don't pass.