### PR TITLE
Use BaseBiteStrength = 0 for floating eyes, remove obsolete comment

### DIFF
--- a/Script/char.dat
+++ b/Script/char.dat
@@ -4549,8 +4549,6 @@ floatingeye
   TotalSize = 40;
   Adjective = "floating";
   NameSingular = "eye";
-  /* AttackStyle is not used */
-  BaseBiteStrength = 1;
   CanBeGenerated = true;
   FleshMaterial = FLOATING_EYE_FLESH;
   IgnoreDanger = true;


### PR DESCRIPTION
Fixes #210.