### PR TITLE
Add list of dependencies to INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,15 @@
 Compiling IVAN under different systems
 --------------------------------------
 
+To build IVAN from source, you need to have the following dependencies
+installed on your system:
+
+- compiler with C++11 support (e.g. Clang 3.3 or newer, GCC 4.8 or newer)
+- CMake (https://cmake.org) version 2.8.12.2 or newer
+- SDL (https://www.libsdl.org) version 1.2 or newer, at least 2.0 recommended
+
+--------------------------------------
+
 Under Linux and OS X, type:
 
 cmake .
@@ -21,11 +30,6 @@ If you have DJGPP 2.03+ and gcc 2.952+
 installed, type:
 
 make -f ivandj.mak
-
-You need to install SDL development libraries,
-which can be downloaded from:
-
-http://www.libsdl.org/
 
 --------------------------------------
 


### PR DESCRIPTION
As noticed in #233, GCC 4.8 or newer is required to build IVAN. Add that to the build instructions, along with some other dependencies and their minimum versions. 