### PR TITLE
Add instructions on how to install IVAN to a custom prefix

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -22,6 +22,11 @@ cmake -D CMAKE_CXX_FLAGS=-DWIZARD .
 make -j
 make install
 
+To install IVAN to a custom prefix, pass the additional flag
+-DCMAKE_INSTALL_PREFIX=/your/prefix/path to the cmake invocation.
+(In particular, simply doing `make DESTDIR=/your/prefix/path install`
+doesn't work because IVAN needs the prefix information at build-time.)
+
 --------------------------------------
 
 Under DOS:


### PR DESCRIPTION
This is useful information because `make DESTDIR=… install` doesn't work for IVAN.

This was noticed thanks to #235.