### PR TITLE
Add space after ### to render headings properly

### DIFF
--- a/releasing.md
+++ b/releasing.md
@@ -1,22 +1,22 @@
 To do for each release
 ----------------------
 
-###Pull from master
+### Pull from master
 
-###Things to change around in the code:
+### Things to change around in the code:
 
  - Update the IVAN version number in the root CMakeLists.txt from 0.50.8 to 0.50.9, depending on what the next version is
  - Search for "increment" in the project files and increment the number associated with the bone files, savefiles and high score versions etc
  - Update this file (releasing.md) to the _next_ release number with the instructions for the next release
 
-###Things to change around on the web:
+### Things to change around on the web:
 
  - Announce the release on the RogueBasin main page at www.roguebasin.com.
  - Update the [IVAN wiki page at RogueBasin](http://www.roguebasin.com/index.php?title=IVAN) with the new version number and release date.
 
-###Compile the game
+### Compile the game
 
-###Include the following files in a zip folder for each release:
+### Include the following files in a zip folder for each release:
 
 **Folder: IvanWin0509**
 
@@ -88,7 +88,7 @@ To do for each release
 
 **Leave only dungeon data files in here**
 
-###Then commit changes, with the release tag v0509
+### Then commit changes, with the release tag v0509
 Tag can be appended to latest commit
 
-###Push changes
+### Push changes


### PR DESCRIPTION
Apparently GitHub doesn't render ### without a space as a heading anymore.