### PR TITLE
Fix build with CMake flag -DBUILD_SHARED_LIBS=ON

### DIFF
--- a/Main/Source/main.cpp
+++ b/Main/Source/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
 
 #endif /* __DJGPP__ */
 
-  audio::Init();
+  audio::Init(game::GetMusicDir());
 
   femath::SetSeed(time(0));
   game::InitGlobalValueMap();

--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB FEAUDIO_SOURCES *.h *.cpp)
 
 add_library(FeAudio ${FEAUDIO_SOURCES})
+target_link_libraries(FeAudio FeLib)
 
 # Add RtMidi dependencies on Windows
 if(WIN32)

--- a/audio/audio.cpp
+++ b/audio/audio.cpp
@@ -70,6 +70,7 @@ std::vector<musicfile*> audio::Tracks;
 RtMidiOut* audio::midiout = 0;
 
 char* audio::CurrentTrack;
+festring audio::MusDir;
 
 /** For each increase in intensity, the respective MIDI channel changes by the following amount */
 int  audio::DeltaVolumePerIntensity[MAX_MIDI_CHANNELS] = {0, 0, 0, 0, 0, -1, -1, -1, -1, 0, -1, 1, 1, 1, 1, 1};
@@ -85,7 +86,7 @@ void audio::error(RtMidiError::Type type, const std::string &errorText, void *us
 
 }
 
-void audio::Init()
+void audio::Init(cfestring& musicDirectory)
 {
    int audio_rate, audio_channels;
    unsigned short audio_format;
@@ -102,6 +103,7 @@ void audio::Init()
    TargetIntensity = 0;
    volumeChangeRequest = false;
    CurrentTrack = 0;
+   MusDir = musicDirectory;
 
    // RtMidiOut constructor
    try
@@ -167,7 +169,6 @@ int audio::Loop(void *ptr)
          int randomIndex = rand() % Tracks.size();
          CurrentTrack = Tracks[randomIndex]->GetFilename();
 
-         festring MusDir = game::GetMusicDir();
          festring MusFile = MusDir + festring(CurrentTrack);
 
          PlayMIDIFile( (char*)MusFile.CStr(), 1);

--- a/audio/audio.h
+++ b/audio/audio.h
@@ -82,7 +82,10 @@ public:
 
    static void error(RtMidiError::Type type, const std::string &errorText, void *userData );
 
-   static void Init();
+   /**
+    * @param musicDirectory path to the directory containing the MIDI files to load.
+    */
+   static void Init(cfestring& musicDirectory);
    static void DeInit(void);
 
    static int Loop(void *ptr);
@@ -148,6 +151,7 @@ private:
 
    static int  PlaybackState;
    static char* CurrentTrack;
+   static festring MusDir;
 
    static std::vector<musicfile*> Tracks;
 


### PR DESCRIPTION
I.e. allow building the FeLib and FeAudio targets as dynamic libraries by removing FeAudio's dependency on the actual game (dynamic libraries don't allow dependency cycles), and by linking FeAudio with FeLib to avoid undefined reference errors.