### PR TITLE
Fix infinite loop in SetPlaybackStatus

### DIFF
--- a/audio/audio.cpp
+++ b/audio/audio.cpp
@@ -59,7 +59,7 @@ int audio::CurrentIntensity;
 bool audio::isInit;
 
 int audio::PlaybackState;
-bool audio::isTrackPlaying;
+volatile bool audio::isTrackPlaying;
 
 bool audio::volumeChangeRequest;
 

--- a/audio/audio.h
+++ b/audio/audio.h
@@ -145,7 +145,7 @@ private:
    static int  TargetIntensity;
    static int  CurrentIntensity;
 
-   static bool isTrackPlaying;
+   static volatile bool isTrackPlaying;
 
    static int CurrentPosition;
 


### PR DESCRIPTION
[This](https://github.com/Attnam/ivan/blob/597a187c6857feb528ec9cfc1a586a8f898fa786/audio/audio.cpp#L391-L394) was being optimized into an infinite loop when building with optimizations enabled, which results in a hang when starting a new game. Closes #235.

(How did this go unnoticed for so long? Are the releases not being built with optimizations?)