### PR TITLE
Fix crash when stopping digging after becoming hungry

### DIFF
--- a/Main/Source/actions.cpp
+++ b/Main/Source/actions.cpp
@@ -253,7 +253,11 @@ void dig::Handle()
   Actor->EditAP(-200000 / APBonus(Actor->GetAttribute(DEXTERITY)));
   Actor->EditNP(-500);
 
-  if(Terrain->GetHP() <= 0)
+  truth TerrainDestroyed = Terrain->GetHP() <= 0;
+  truth AlreadyTerminated = Actor->GetAction() != this;
+  truth StoppedDigging = TerrainDestroyed || AlreadyTerminated;
+
+  if(TerrainDestroyed)
   {
     if(Square->CanBeSeenByPlayer())
       ADD_MESSAGE("%s", Terrain->GetDigMessage().CStr());
@@ -265,6 +269,12 @@ void dig::Handle()
     if(!Actor->IsEnabled())
       return;
 
+    if(!AlreadyTerminated)
+      Terminate(true);
+  }
+
+  if(StoppedDigging)
+  {
     if(MoveDigger && Actor->GetMainWielded())
       Actor->GetMainWielded()->MoveTo(Actor->GetStack());
 
@@ -283,11 +293,9 @@ void dig::Handle()
       LeftBackup->RemoveFromSlot();
       Actor->SetLeftWielded(LeftBackup);
     }
-
-    if(Actor->GetAction() == this) // Not already terminated?
-      Terminate(true);
   }
-  else
+
+  if(!TerrainDestroyed)
     game::DrawEverything();
 }
 

--- a/Main/Source/actions.cpp
+++ b/Main/Source/actions.cpp
@@ -241,6 +241,14 @@ void dig::Handle()
 
   int Damage = Actor->GetAttribute(ARM_STRENGTH) * Digger->GetMainMaterial()->GetStrengthValue() / 500;
   Terrain->EditHP(-Max(Damage, 1));
+
+  /* Save these here because the EditNP call below can cause 'this' to be terminated
+     and deleted, if the player decides to stop digging because of becoming hungry. */
+
+  truth MoveDigger = this->MoveDigger;
+  ulong RightBackupID = this->RightBackupID;
+  ulong LeftBackupID = this->LeftBackupID;
+
   Actor->EditExperience(ARM_STRENGTH, 200, 1 << 5);
   Actor->EditAP(-200000 / APBonus(Actor->GetAttribute(DEXTERITY)));
   Actor->EditNP(-500);
@@ -276,7 +284,8 @@ void dig::Handle()
       Actor->SetLeftWielded(LeftBackup);
     }
 
-    Terminate(true);
+    if(Actor->GetAction() == this) // Not already terminated?
+      Terminate(true);
   }
   else
     game::DrawEverything();


### PR DESCRIPTION
Also, the player's old wielded item wasn't being wielded again when stopping digging this way. This fixes that as well.

Closes #120.