### PR TITLE
Helmets give protection from sound attacks

### DIFF
--- a/Main/Include/char.h
+++ b/Main/Include/char.h
@@ -140,6 +140,7 @@ struct characterdatabase : public databasebase
   int PoisonResistance;
   int ElectricityResistance;
   int AcidResistance;
+  int SoundResistance;
   int ConsumeFlags;
   long TotalVolume;
   packv2 HeadBitmapPos;
@@ -484,6 +485,7 @@ class character : public entity, public id
   DATA_BASE_VALUE(int, PoisonResistance);
   DATA_BASE_VALUE(int, ElectricityResistance);
   DATA_BASE_VALUE(int, AcidResistance);
+  DATA_BASE_VALUE(int, SoundResistance);
   DATA_BASE_VALUE(int, ConsumeFlags);
   DATA_BASE_VALUE(long, TotalVolume);
   virtual DATA_BASE_VALUE(v2, HeadBitmapPos);

--- a/Main/Include/item.h
+++ b/Main/Include/item.h
@@ -136,6 +136,7 @@ struct itemdatabase : public databasebase
   int ElectricityResistance;
   int AcidResistance;
   int StrengthModifier;
+  int SoundResistance;
   int FormModifier;
   int DefaultSize;
   long DefaultMainVolume;
@@ -324,6 +325,7 @@ class item : public object
   DATA_BASE_VALUE(int, PoisonResistance);
   DATA_BASE_VALUE(int, ElectricityResistance);
   DATA_BASE_VALUE(int, AcidResistance);
+  DATA_BASE_VALUE(int, SoundResistance);
   DATA_BASE_VALUE(int, StrengthModifier);
   virtual DATA_BASE_VALUE(int, FormModifier);
   DATA_BASE_VALUE(int, DefaultSize);

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -3846,7 +3846,6 @@ int character::GetResistance(int Type) const
   switch(Type&0xFFF)
   {
    case PHYSICAL_DAMAGE:
-   case SOUND:
    case DRAIN:
    case MUSTARD_GAS_DAMAGE:
    case PSI:
@@ -3856,6 +3855,7 @@ int character::GetResistance(int Type) const
    case POISON: return GetPoisonResistance();
    case ELECTRICITY: return GetElectricityResistance();
    case ACID: return GetAcidResistance();
+   case SOUND: return GetSoundResistance();
   }
 
   ABORT("Resistance lack detected!");

--- a/Main/Source/database.cpp
+++ b/Main/Source/database.cpp
@@ -355,6 +355,7 @@ template<> void databasecreator<character>::CreateDataBaseMemberMap()
   ADD_MEMBER(PoisonResistance);
   ADD_MEMBER(ElectricityResistance);
   ADD_MEMBER(AcidResistance);
+  ADD_MEMBER(SoundResistance);
   ADD_MEMBER(IsUnique);
   ADD_MEMBER(ConsumeFlags);
   ADD_MEMBER(TotalVolume);
@@ -523,6 +524,7 @@ template<> void databasecreator<item>::CreateDataBaseMemberMap()
   ADD_MEMBER(PoisonResistance);
   ADD_MEMBER(ElectricityResistance);
   ADD_MEMBER(AcidResistance);
+  ADD_MEMBER(SoundResistance);
   ADD_MEMBER(StrengthModifier);
   ADD_MEMBER(FormModifier);
   ADD_MEMBER(DefaultSize);

--- a/Main/Source/item.cpp
+++ b/Main/Source/item.cpp
@@ -445,7 +445,6 @@ int item::GetResistance(int Type) const
   switch(Type&0xFFF)
   {
    case PHYSICAL_DAMAGE: return GetStrengthValue();
-   case SOUND:
    case ENERGY:
    case DRAIN:
    case MUSTARD_GAS_DAMAGE:
@@ -454,6 +453,7 @@ int item::GetResistance(int Type) const
    case POISON: return GetPoisonResistance();
    case ELECTRICITY: return GetElectricityResistance();
    case ACID: return GetAcidResistance();
+   case SOUND: return GetSoundResistance();
   }
 
   ABORT("Resistance lack detected!");

--- a/Script/char.dat
+++ b/Script/char.dat
@@ -50,6 +50,7 @@ character
   PoisonResistance = 0;
   ElectricityResistance = 0;
   AcidResistance = 0;
+  SoundResistance = 0;
   IsUnique = false;
   ConsumeFlags = CT_FRUIT|CT_MEAT|CT_LIQUID|CT_PROCESSED;
   /* Obligatory: TotalVolume */

--- a/Script/item.dat
+++ b/Script/item.dat
@@ -2887,7 +2887,7 @@ helmet
   CoverPercentile = 50;
   HelmetBitmapPos = 112, 416;
   EnchantmentPlusChance = 15;
-  SoundResistance = 1;
+  SoundResistance = 0;
 
   Config BROKEN;
   {
@@ -2914,7 +2914,7 @@ helmet
     CoverPercentile = 90;
     HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 10;
-    SoundResistance = 2;
+    SoundResistance = 1;
   }
 
   Config BROKEN|FULL_HELMET;
@@ -2946,6 +2946,7 @@ helmet
     CoverPercentile = 90;
     HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
+    SoundResistance = 1;
   }
 
   Config BROKEN|HELM_OF_PERCEPTION;
@@ -2977,6 +2978,7 @@ helmet
     CoverPercentile = 90;
     HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
+    SoundResistance = 1;
   }
 
   Config BROKEN|HELM_OF_UNDERSTANDING;
@@ -3007,6 +3009,7 @@ helmet
     CoverPercentile = 90;
     HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
+    SoundResistance = 1;
   }
 
   Config BROKEN|HELM_OF_BRILLIANCE;
@@ -3038,6 +3041,7 @@ helmet
     CoverPercentile = 90;
     HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
+    SoundResistance = 1;
   }
 
   Config BROKEN|HELM_OF_ATTRACTIVITY;

--- a/Script/item.dat
+++ b/Script/item.dat
@@ -2887,6 +2887,7 @@ helmet
   CoverPercentile = 50;
   HelmetBitmapPos = 112, 416;
   EnchantmentPlusChance = 15;
+  SoundResistance = 1;
 
   Config BROKEN;
   {
@@ -2896,6 +2897,7 @@ helmet
     MaterialConfigChances = { 7, 100, 25, 25, 25, 25, 10, 5; }
     HelmetBitmapPos = 112, 496;
     EnchantmentPlusChance = 30;
+    SoundResistance = 0;
   }
 
   Config FULL_HELMET;
@@ -2912,6 +2914,7 @@ helmet
     CoverPercentile = 90;
     HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 10;
+    SoundResistance = 2;
   }
 
   Config BROKEN|FULL_HELMET;
@@ -3069,6 +3072,7 @@ helmet
     CoverPercentile = 100;
     HelmetBitmapPos = 112, 432;
     EnchantmentPlusChance = 0;
+    SoundResistance = 0;
   }
 }
 


### PR DESCRIPTION
Conventional helmets give some finite protection against sound attacks directed at a character's head.
Full helmets give seemingly 100% protection against point-blank Enner beast's attack when directed at character's head.
Note that special helmets give same protection as conventional helmets.
Broken helmets give no protection whatsoever.