### PR TITLE
Use SDL_UpdateTexture() if SDL_LockTexture() fails

### DIFF
--- a/FeLib/Source/graphics.cpp
+++ b/FeLib/Source/graphics.cpp
@@ -279,12 +279,16 @@ void graphics::BlitDBToScreen()
   void* DestPtr;
   int Pitch;
 
-  if (SDL_LockTexture(Texture, NULL, &DestPtr, &Pitch) < 0)
-    ABORT("Can't lock texture");
-
-  memcpy(DestPtr, SrcPtr, Res.Y * Pitch);
-
-  SDL_UnlockTexture(Texture);
+  if (SDL_LockTexture(Texture, NULL, &DestPtr, &Pitch) == 0)
+  {
+    memcpy(DestPtr, SrcPtr, Res.Y * Pitch);
+    SDL_UnlockTexture(Texture);
+  }
+  else
+  {
+    // Try to use the slower SDL_UpdateTexture() as a fallback if SDL_LockTexture() fails.
+    SDL_UpdateTexture(Texture, NULL, SrcPtr, Res.X * sizeof(packcol16));
+  }
 
   SDL_RenderClear(Renderer);
   SDL_RenderCopy(Renderer, Texture, NULL, NULL);


### PR DESCRIPTION
This is an attempt to fix #278. However since I don't have a Windows XP to test on I don't know if this actually fixes it.

This basically reverts to the old behavior of using `SDL_UpdateTexture()` instead of `SDL_LockTexture()` et al. (see commit 50d4d25e14bd444a605115cdb99f3ea7eb288b19).

