### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.mak]
+indent_style = tab


### PR DESCRIPTION
(see http://editorconfig.org)

so I don't have to manually switch my editor's indent size setting everytime I start working on IVAN after working on some other project with a different indent size.