### PR TITLE
Make headless characters blind

### DIFF
--- a/Main/Include/char.h
+++ b/Main/Include/char.h
@@ -1101,6 +1101,7 @@ class character : public entity, public id
   int GetRandomBodyPart(ulong = ALL_BODYPART_FLAGS) const;
   virtual truth CanChokeOnWeb(web*) const { return CanChoke(); }
   virtual truth BrainsHurt() const { return false; }
+  virtual truth IsHeadless() const { return false; }
   truth IsSwimming() const;
   truth IsAnimated() const;
   virtual truth IsPlayerKind() const { return false; }

--- a/Main/Include/human.h
+++ b/Main/Include/human.h
@@ -162,6 +162,7 @@ CHARACTER(humanoid, character)
   virtual truth AllowUnconsciousness() const;
   virtual truth CanChokeOnWeb(web*) const;
   virtual truth BrainsHurt() const;
+  virtual truth IsHeadless() const;
   virtual cchar* GetRunDescriptionLine(int) const;
   virtual cchar* GetNormalDeathMessage() const;
   virtual void ApplySpecialAttributeBonuses();

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -8603,6 +8603,9 @@ int character::GetAttribute(int Identifier, truth AllowBonus) const
   if(AllowBonus && Identifier == INTELLIGENCE && BrainsHurt())
     return Max((A + AttributeBonus[INTELLIGENCE]) / 3, 1);
 
+  if(AllowBonus && Identifier == PERCEPTION && IsHeadless())
+    return 0;
+
   return A && AllowBonus ? Max(A + AttributeBonus[Identifier], 1) : A;
 }
 

--- a/Main/Source/human.cpp
+++ b/Main/Source/human.cpp
@@ -784,7 +784,7 @@ void priest::BeTalkedTo()
         return;
       }
     }
-    else 
+    else
       ADD_MESSAGE("\"Good %s, you're on fire! Quick, go find %ld gold so that I can help!\"", GetMasterGod()->GetName(), Price);
   }
 
@@ -5697,6 +5697,12 @@ truth humanoid::BrainsHurt() const
 {
   head* Head = GetHead();
   return !Head || Head->IsBadlyHurt();
+}
+
+truth humanoid::IsHeadless() const
+{
+  head* Head = GetHead();
+  return !Head;
 }
 
 void playerkind::PostConstruct()


### PR DESCRIPTION
Previously, you could still see normally once you lost your head (and survived). Now zombies will now be blind without a head.