### PR TITLE
optionally shows the turn number on log messages

### DIFF
--- a/Main/Include/iconf.h
+++ b/Main/Include/iconf.h
@@ -30,6 +30,7 @@ class ivanconfig
   static truth GetSmartOpenCloseApply() { return SmartOpenCloseApply.Value; }
   static truth GetBeNice() { return BeNice.Value; }
   static truth GetPlaySounds() { return PlaySounds.Value; }
+  static truth GetShowTurn() { return ShowTurn.Value; }
   static long GetVolume() { return Volume.Value; }
   static long GetMIDIOutputDevice() { return MIDIOutputDevice.Value; }
 #ifndef __DJGPP__
@@ -88,6 +89,7 @@ class ivanconfig
 #endif
   static col24 ContrastLuminance;
   static truthoption PlaySounds;
+  static truthoption ShowTurn;
 };
 
 inline long ivanconfig::ApplyContrastTo(long L)

--- a/Main/Source/iconf.cpp
+++ b/Main/Source/iconf.cpp
@@ -88,6 +88,7 @@ truthoption ivanconfig::FullScreenMode(   "FullScreenMode",
 #endif
 col24 ivanconfig::ContrastLuminance = NORMAL_LUMINANCE;
 truthoption ivanconfig::PlaySounds("PlaySounds", "use sounds", true);
+truthoption ivanconfig::ShowTurn("ShowTurn", "show the turn on log messages", false);
 
 v2 ivanconfig::GetQuestionPos() { return game::IsRunning() ? v2(16, 6) : v2(30, 30); }
 void ivanconfig::BackGroundDrawer() { game::DrawEverythingNoBlit(); }
@@ -322,6 +323,7 @@ void ivanconfig::Initialize()
   configsystem::AddOption(&DirectionKeyMap);
   configsystem::AddOption(&SmartOpenCloseApply);
   configsystem::AddOption(&BeNice);
+  configsystem::AddOption(&ShowTurn);
   configsystem::AddOption(&PlaySounds);
   configsystem::AddOption(&Volume);
 

--- a/Main/Source/message.cpp
+++ b/Main/Source/message.cpp
@@ -96,6 +96,12 @@ void msgsystem::AddMessage(cchar* Format, ...)
   }
 
   festring Temp;
+
+  if(ivanconfig::GetShowTurn())
+  {
+    Temp << game::GetTurn() << " ";
+  }
+
   Temp << Begin.X << ':';
 
   if(Begin.Y < 10)


### PR DESCRIPTION
the turn will be prepended just before the time.
I always found it to be confusing what happened when before it.