### PR TITLE
Change BROKEN_LOCK definition to 32768 instead of S_LOCK_ID

### DIFF
--- a/Main/Include/ivandef.h
+++ b/Main/Include/ivandef.h
@@ -676,7 +676,7 @@ cv2 SILHOUETTE_SIZE(48, 64);
 
 #define LOCK_BITS 0xFC00
 
-#define BROKEN_LOCK S_LOCK_ID
+#define BROKEN_LOCK 32768
 
 /* Normal lock types, which can be randomized */
 

--- a/Script/define.dat
+++ b/Script/define.dat
@@ -970,7 +970,7 @@
 #define S_LOCK_ID 16384
 #define LOCK_DELTA 1024
 
-#define BROKEN_LOCK S_LOCK_ID
+#define BROKEN_LOCK 32768
 
 /* Normal lock types, which can be randomized */
 


### PR DESCRIPTION
This makes secret (hexagonal, octagonal etc.) keys open their respective locks instead of getting the "lock is broken" message. 