### PR TITLE
(ready) Add item label

### DIFF
--- a/.devsPrefs/AquariusPower/.gitignore.AquariusPower
+++ b/.devsPrefs/AquariusPower/.gitignore.AquariusPower
@@ -80,3 +80,5 @@ dbgmsg.h
 dbgmsg.cpp
 /Linux/
 /SDL2-2.0.4/
+build
+build.*

--- a/Main/Include/command.h
+++ b/Main/Include/command.h
@@ -82,6 +82,7 @@ class commandsystem
   static truth WieldInRightArm(character*);
   static truth WieldInLeftArm(character*);
   static truth AssignName(character*);
+  static truth SetItemLabel(character*);
   static truth Search(character*);
   static truth Consume(character*, cchar*, sorter);
 #ifdef WIZARD

--- a/Main/Include/item.h
+++ b/Main/Include/item.h
@@ -263,6 +263,7 @@ class item : public object
   virtual truth CanBeEatenByAI(ccharacter*) const;
   virtual truth IsExplosive() const { return false; }
   virtual void SetLabel(cfestring& What);
+  virtual cfestring& GetLabel() const { return label; }
   virtual void AddName(festring&, int) const;
   virtual void AddName(festring& a, int b, int c) const {object::AddName(a,b,c);} //required because of AddName(festring&,int)
   virtual void Save(outputfile&) const;

--- a/Main/Include/item.h
+++ b/Main/Include/item.h
@@ -262,6 +262,9 @@ class item : public object
   virtual void SignalSquarePositionChange(int);
   virtual truth CanBeEatenByAI(ccharacter*) const;
   virtual truth IsExplosive() const { return false; }
+  virtual void SetLabel(cfestring& What);
+  virtual void AddName(festring&, int) const;
+  virtual void AddName(festring& a, int b, int c) const {object::AddName(a,b,c);} //required because of AddName(festring&,int)
   virtual void Save(outputfile&) const;
   virtual void Load(inputfile&);
   virtual void ChargeFully(character*) { }
@@ -630,6 +633,7 @@ class item : public object
   fluid** Fluid;
   int SquaresUnder;
   int LifeExpectancy;
+  festring label;
   ulong ItemFlags;
   int iRotateFlyingThrownStep;
   virtual truth NeedsBurningPostFix() const { return IsBurning(); }

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -76,11 +76,12 @@ command* commandsystem::Command[] =
   new command(&Go, "go", 'g', 'g', 'g', false),
   new command(&GoDown, "go down/enter area", '>', '>', '>', true),
   new command(&GoUp, "go up", '<', '<', '<', true),
+  new command(&SetItemLabel, "inscribe item", 'b', 'b', 'b', true),
   new command(&IssueCommand, "issue command(s) to team member(s)", 'I', 'I', 'I', false),
   new command(&Kick, "kick", 'k', 'K', 'K', false),
   new command(&Look, "look", 'l', 'L', 'L', true),
   new command(&ShowMap, "show map", 'm', 'm', 'm', false),
-  new command(&AssignName , "name"     , 'n', 'n', 'N', false),
+  new command(&AssignName , "name", 'n', 'n', 'N', false),
   new command(&Offer, "offer", 'O', 'f', 'O', false),
   new command(&Open, "open", 'o', 'O', 'o', false),
   new command(&PickUp, "pick up", ',', ',', ',', false),
@@ -91,7 +92,6 @@ command* commandsystem::Command[] =
   new command(&Save, "save game", 'S', 'S', 'S', true),
   new command(&ScrollMessagesDown, "scroll messages down", '+', '+', '+', true),
   new command(&ScrollMessagesUp, "scroll messages up", '-', '-', '-', true),
-  new command(&SetItemLabel, "set item label", 'L', 'l', 'l', true),
   new command(&ShowConfigScreen, "show config screen", '\\', '\\', '\\', true),
   new command(&ShowInventory, "show inventory", 'i', 'i', 'i', true),
   new command(&ShowKeyLayout, "show key layout", '?', '?', '?', true),
@@ -493,7 +493,7 @@ truth commandsystem::SetItemLabel(character* Char)
 {
   if(!Char->GetStack()->GetItems())
   {
-    ADD_MESSAGE("You have nothing to add a label!");
+    ADD_MESSAGE("You have nothing to inscribe!");
     return false;
   }
 
@@ -503,13 +503,13 @@ truth commandsystem::SetItemLabel(character* Char)
   {
     itemvector ToAddLabel;
     game::DrawEverythingNoBlit();
-    Char->GetStack()->DrawContents(ToAddLabel, Char, CONST_S("What do you want to add a label?"), REMEMBER_SELECTED);
+    Char->GetStack()->DrawContents(ToAddLabel, Char, CONST_S("What do you want to inscribe?"), REMEMBER_SELECTED);
 
     if(ToAddLabel.empty())
       break;
 
     festring What = ToAddLabel[0]->GetLabel();
-    if(game::StringQuestion(What, CONST_S("How you want to label it?"), WHITE, 0, 20, true) == NORMAL_EXIT)
+    if(game::StringQuestion(What, CONST_S("What would you like to inscribe in this item?"), WHITE, 0, 20, true) == NORMAL_EXIT)
       for(int i=0;i<ToAddLabel.size();i++)
         ToAddLabel[i]->SetLabel(What);
   }

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -508,7 +508,7 @@ truth commandsystem::SetItemLabel(character* Char)
     if(ToAddLabel.empty())
       break;
 
-    festring What;
+    festring What = ToAddLabel[0]->GetLabel();
     if(game::StringQuestion(What, CONST_S("How you want to label it?"), WHITE, 0, 20, true) == NORMAL_EXIT)
       for(int i=0;i<ToAddLabel.size();i++)
         ToAddLabel[i]->SetLabel(What);

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -80,7 +80,7 @@ command* commandsystem::Command[] =
   new command(&Kick, "kick", 'k', 'K', 'K', false),
   new command(&Look, "look", 'l', 'L', 'L', true),
   new command(&ShowMap, "show map", 'm', 'm', 'm', false),
-  new command(&AssignName, "name", 'n', 'n', 'N', false),
+  new command(&AssignName , "name"     , 'n', 'n', 'N', false),
   new command(&Offer, "offer", 'O', 'f', 'O', false),
   new command(&Open, "open", 'o', 'O', 'o', false),
   new command(&PickUp, "pick up", ',', ',', ',', false),
@@ -91,6 +91,7 @@ command* commandsystem::Command[] =
   new command(&Save, "save game", 'S', 'S', 'S', true),
   new command(&ScrollMessagesDown, "scroll messages down", '+', '+', '+', true),
   new command(&ScrollMessagesUp, "scroll messages up", '-', '-', '-', true),
+  new command(&SetItemLabel, "set item label", 'L', 'l', 'l', true),
   new command(&ShowConfigScreen, "show config screen", '\\', '\\', '\\', true),
   new command(&ShowInventory, "show inventory", 'i', 'i', 'i', true),
   new command(&ShowKeyLayout, "show key layout", '?', '?', '?', true),
@@ -484,6 +485,34 @@ truth commandsystem::Close(character* Char)
   }
   else
     ADD_MESSAGE("This monster type cannot close anything.");
+
+  return false;
+}
+
+truth commandsystem::SetItemLabel(character* Char)
+{
+  if(!Char->GetStack()->GetItems())
+  {
+    ADD_MESSAGE("You have nothing to add a label!");
+    return false;
+  }
+
+  stack::SetSelected(0);
+
+  for(;;)
+  {
+    itemvector ToAddLabel;
+    game::DrawEverythingNoBlit();
+    Char->GetStack()->DrawContents(ToAddLabel, Char, CONST_S("What do you want to add a label?"), REMEMBER_SELECTED);
+
+    if(ToAddLabel.empty())
+      break;
+
+    festring What;
+    if(game::StringQuestion(What, CONST_S("How you want to label it?"), WHITE, 0, 20, true) == NORMAL_EXIT)
+      for(int i=0;i<ToAddLabel.size();i++)
+        ToAddLabel[i]->SetLabel(What);
+  }
 
   return false;
 }

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -76,7 +76,7 @@ command* commandsystem::Command[] =
   new command(&Go, "go", 'g', 'g', 'g', false),
   new command(&GoDown, "go down/enter area", '>', '>', '>', true),
   new command(&GoUp, "go up", '<', '<', '<', true),
-  new command(&SetItemLabel, "inscribe item", 'b', 'b', 'b', true),
+  new command(&SetItemLabel, "inscribe on item", 'b', 'b', 'b', true),
   new command(&IssueCommand, "issue command(s) to team member(s)", 'I', 'I', 'I', false),
   new command(&Kick, "kick", 'k', 'K', 'K', false),
   new command(&Look, "look", 'l', 'L', 'L', true),
@@ -493,7 +493,7 @@ truth commandsystem::SetItemLabel(character* Char)
 {
   if(!Char->GetStack()->GetItems())
   {
-    ADD_MESSAGE("You have nothing to inscribe!");
+    ADD_MESSAGE("You have nothing to inscribe on!");
     return false;
   }
 
@@ -503,13 +503,13 @@ truth commandsystem::SetItemLabel(character* Char)
   {
     itemvector ToAddLabel;
     game::DrawEverythingNoBlit();
-    Char->GetStack()->DrawContents(ToAddLabel, Char, CONST_S("What do you want to inscribe?"), REMEMBER_SELECTED);
+    Char->GetStack()->DrawContents(ToAddLabel, Char, CONST_S("What item do you want to inscribe on?"), REMEMBER_SELECTED);
 
     if(ToAddLabel.empty())
       break;
 
     festring What = ToAddLabel[0]->GetLabel();
-    if(game::StringQuestion(What, CONST_S("What would you like to inscribe in this item?"), WHITE, 0, 20, true) == NORMAL_EXIT)
+    if(game::StringQuestion(What, CONST_S("What would you like to inscribe on this item?"), WHITE, 0, 20, true) == NORMAL_EXIT)
       for(int i=0;i<ToAddLabel.size();i++)
         ToAddLabel[i]->SetLabel(What);
   }

--- a/Main/Source/item.cpp
+++ b/Main/Source/item.cpp
@@ -401,6 +401,23 @@ truth item::CanBeEatenByAI(ccharacter* Eater) const
     && ConsumeMaterial && ConsumeMaterial->CanBeEatenByAI(Eater);
 }
 
+void item::SetLabel(cfestring& What)
+{
+  label.Empty();
+  if(What.GetSize()>0)
+    label << What;
+}
+
+void item::AddName(festring& Name, int Case) const
+{
+  if(label.GetSize())
+    Name << label << " "; //this way user can decide how it should look, with or w/o delimiters and which ones
+//    Name << "{"<<label<<"}" << " ";
+//    Name << "#"<<label << " ";
+
+  object::AddName(Name,Case);
+}
+
 void item::Save(outputfile& SaveFile) const
 {
   SaveFile << static_cast<ushort>(GetType());
@@ -408,6 +425,9 @@ void item::Save(outputfile& SaveFile) const
   SaveFile << static_cast<ushort>(GetConfig());
   SaveFile << static_cast<ushort>(Flags);
   SaveFile << Size << ID << LifeExpectancy << ItemFlags;
+  if(game::GetSaveFileVersion()>=132){
+    SaveFile << label;
+  }
   SaveLinkedList(SaveFile, CloneMotherID);
 
   if(Fluid)
@@ -427,6 +447,9 @@ void item::Load(inputfile& SaveFile)
   databasecreator<item>::InstallDataBase(this, ReadType<ushort>(SaveFile));
   Flags |= ReadType<ushort>(SaveFile) & ~ENTITY_FLAGS;
   SaveFile >> Size >> ID >> LifeExpectancy >> ItemFlags;
+  if(game::GetSaveFileVersion()>=132){
+    SaveFile >> label;
+  }
   LoadLinkedList(SaveFile, CloneMotherID);
 
   if(LifeExpectancy)
@@ -880,7 +903,8 @@ truth item::CanBePiledWith(citem* Item, ccharacter* Viewer) const
           && Viewer->GetSWeaponSkillLevel(this) == Viewer->GetSWeaponSkillLevel(Item)
           && !Fluid && !Item->Fluid
           && !LifeExpectancy == !Item->LifeExpectancy
-          && !IsBurning() == !Item->IsBurning());
+          && !IsBurning() == !Item->IsBurning()
+          && label==Item->label );
 }
 
 void item::Break(character* Breaker, int)


### PR DESCRIPTION
Now the user can add a label to any item (or amount of equal items), they will stack if having same label (or none as vanilla).
![selection_094](https://user-images.githubusercontent.com/17087075/40637913-5f101866-62de-11e8-9e01-a14f849c11bc.jpg)

should it be called something else than "label"?

as you can see, I didnt force any delimiters (should I?) to let user decide how it should look.

it is prepended, should be elsewhere?

should be more immersive? (use a dagger to engrave the item (hard floors should require it too btw)? :), trying to engrave a wand may make it explode etc. Should it give exp to int or wisdom?)

for now it is just useful:
- an empty wand
- items to sell
- something to be kept for special event
- a small chest that belongs to pet inventory
- a small chest only for magical items
