### PR TITLE
Add a graphics option for nearest-neighbor and linear interpolation

### DIFF
--- a/FeLib/Include/graphics.h
+++ b/FeLib/Include/graphics.h
@@ -41,13 +41,14 @@ class graphics
 #ifdef USE_SDL
   static void SetScale(int);
   static void SwitchMode();
+  static void SetMode(cchar*, cchar*, v2, int, int, truth);
 #endif
 
 #ifdef __DJGPP__
   static void SwitchMode() { }
+  static void SetMode(cchar*, cchar*, v2, truth);
 #endif
 
-  static void SetMode(cchar*, cchar*, v2, int, truth);
   static void Stretch(bool, bitmap*, blitdata&, bool);
   static void DrawRectangleOutlineAround(bitmap* bmpAt, v2 v2TopLeft, v2 v2Border, col16 color, bool wide);
   static void BlitDBToScreen();

--- a/FeLib/Source/graphics.cpp
+++ b/FeLib/Source/graphics.cpp
@@ -164,7 +164,8 @@ void graphics::DeInit()
 #ifdef USE_SDL
 
 void graphics::SetMode(cchar* Title, cchar* IconName,
-                       v2 NewRes, int NewScale, truth FullScreen)
+                       v2 NewRes, int NewScale, int ScalingQuality,
+                       truth FullScreen)
 {
 #if SDL_MAJOR_VERSION == 1
   if(IconName)
@@ -220,34 +221,10 @@ void graphics::SetMode(cchar* Title, cchar* IconName,
 
   SDL_RenderSetLogicalSize(Renderer, NewRes.X, NewRes.Y);
 
-  /* The following code will determine whether to use nearest neighbor or
-   * linear interpolation when scaling the game in fullscreen mode. */
-
-  SDL_DisplayMode VirtualDisplayMode;
-  if(SDL_GetDesktopDisplayMode(0, &VirtualDisplayMode) == 0)
-  {
-    v2 ActualWindowRes; // On high-DPI displays this is greater than NewRes.
-    SDL_GL_GetDrawableSize(Window, &ActualWindowRes.X, &ActualWindowRes.Y);
-
-    v2 ActualDisplayRes;
-    if(SDL_GetWindowFlags(Window) & SDL_WINDOW_FULLSCREEN_DESKTOP)
-      ActualDisplayRes = ActualWindowRes;
-    else
-      ActualDisplayRes = v2(ActualWindowRes.X / NewRes.X * VirtualDisplayMode.w,
-                            ActualWindowRes.Y / NewRes.Y * VirtualDisplayMode.h);
-
-    if((ActualDisplayRes.Y % NewRes.Y == 0
-       && ActualDisplayRes.X >= ActualDisplayRes.Y / NewRes.Y * NewRes.X)
-       || (ActualDisplayRes.X % NewRes.X == 0
-       && ActualDisplayRes.Y >= ActualDisplayRes.X / NewRes.X * NewRes.Y))
-      /* In-game pixels can be safely mapped one-on-one to rectangular
-       * units consisting of one or more on-screen pixels. */
-      SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
-    else
-      SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+  switch(ScalingQuality){
+  case 1: SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear"); break;
+  default: SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
   }
-  else
-    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
 
   Texture = SDL_CreateTexture(Renderer,
                               SDL_PIXELFORMAT_RGB565,

--- a/Main/Include/iconf.h
+++ b/Main/Include/iconf.h
@@ -65,6 +65,7 @@ class ivanconfig
 
 #ifndef __DJGPP__
   static int GetGraphicsScale() { return GraphicsScale.Value; }
+  static int GetScalingQuality() { return ScalingQuality.Value; }
   static truth GetFullScreenMode() { return FullScreenMode.Value; }
   static void SwitchModeHandler();
 #else
@@ -126,6 +127,7 @@ class ivanconfig
 
 #ifndef __DJGPP__
   static void GraphicsScaleDisplayer(const cycleoption*, festring&);
+  static void ScalingQualityDisplayer(const cycleoption*, festring&);
   static truth GraphicsScaleChangeInterface(cycleoption*);
   static void GraphicsScaleChanger(cycleoption*, long);
   static void FullScreenModeChanger(truthoption*, truth);
@@ -206,6 +208,7 @@ class ivanconfig
 #ifndef __DJGPP__
   static cycleoption GraphicsScale;
   static truthoption FullScreenMode;
+  static cycleoption ScalingQuality;
 #endif
 
   static col24 ContrastLuminance;

--- a/Main/Source/iconf.cpp
+++ b/Main/Source/iconf.cpp
@@ -221,6 +221,10 @@ truthoption ivanconfig::FullScreenMode(   "FullScreenMode",
                                           &configsystem::NormalTruthDisplayer,
                                           &configsystem::NormalTruthChangeInterface,
                                           &FullScreenModeChanger);
+cycleoption ivanconfig::ScalingQuality(   "ScalingQuality",
+                                          "* scaling quality",
+                                          0, 2,
+                                          &ScalingQualityDisplayer);
 #endif
 col24 ivanconfig::ContrastLuminance = NORMAL_LUMINANCE;
 truthoption ivanconfig::PlaySounds(       "PlaySounds",
@@ -734,6 +738,14 @@ void ivanconfig::FullScreenModeChanger(truthoption*, truth)
   graphics::SwitchMode();
 }
 
+void ivanconfig::ScalingQualityDisplayer(const cycleoption* O, festring& Entry)
+{
+  switch(O->Value){
+  case 0: Entry << "pixelated"; break;
+  case 1: Entry << "smooth"; break;
+  }
+}
+
 #endif
 
 void ivanconfig::Show()
@@ -819,6 +831,9 @@ void ivanconfig::Initialize()
 #endif
 
   fsCategory="Graphics";
+#ifndef __DJGPP__
+  configsystem::AddOption(fsCategory,&ScalingQuality);
+#endif
   configsystem::AddOption(fsCategory,&LookZoom);
   configsystem::AddOption(fsCategory,&XBRZScale);
   configsystem::AddOption(fsCategory,&XBRZSquaresAroundPlayer);

--- a/Main/Source/igraph.cpp
+++ b/Main/Source/igraph.cpp
@@ -75,7 +75,10 @@ void igraph::Init()
     graphics::SetMode("IVAN " IVAN_VERSION,
                       festring(game::GetDataDir() + "Graphics/Icon.bmp").CStr(),
                       v2(ivanconfig::GetStartingWindowWidth(), ivanconfig::GetStartingWindowHeight()),
+#ifndef __DJGPP__
                       ivanconfig::GetGraphicsScale(),
+                      ivanconfig::GetScalingQuality(),
+#endif
                       ivanconfig::GetFullScreenMode());
     DOUBLE_BUFFER->ClearToColor(0);
     graphics::BlitDBToScreen();

--- a/igor/Source/igor.cpp
+++ b/igor/Source/igor.cpp
@@ -50,7 +50,7 @@ int main(int, char**)
   OConfigFile.close();
 
   graphics::Init();
-  graphics::SetMode("IGOR 1.203", 0, v2(800, 600), 1, false);
+  graphics::SetMode("IGOR 1.203", 0, v2(800, 600), 1, 0, false);
   graphics::LoadDefaultFont(Directory + "Font.png");
   DOUBLE_BUFFER->ClearToColor(0);
 


### PR DESCRIPTION
Ping #357. Currently there are "nearest-neighbor" (use British English "neighbour"?) and "linear".

<img width="675" alt="opt-scaling-quality" src="https://user-images.githubusercontent.com/23622455/40691241-8e4c6efe-63dd-11e8-92ae-c3c1a039e104.png">

But the "nearest-neighbor" is too long for in-game menu, so it goes to the next line. Suggestion?

<img width="659" alt="opt-scaling-quality-playing" src="https://user-images.githubusercontent.com/23622455/40691239-8d95a944-63dd-11e8-9587-14ed2b9a858d.png">

p.s. It seems the code for DOSBox is not maintained anymore, should we remove all related code?