### PR TITLE
Fix: iosystem::ContinueMenu() returns too early

### DIFF
--- a/FeLib/Source/feio.cpp
+++ b/FeLib/Source/feio.cpp
@@ -983,8 +983,6 @@ festring iosystem::ContinueMenu(col16 TopicColor, col16 ListColor,
     {
       while( (ep = readdir(dp)) ) addFileInfo(ep->d_name);
       closedir(dp);
-    }else{
-      return "";
     }
   }
 #endif

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -8747,7 +8747,7 @@ void character::ShowAdventureInfoAlt() const
     int Answer =
      game::KeyQuestion(
        CONST_S("See (i)nventory, (m)essage history, (k)ill list, (l)ook or [ESC]/(n)othing?"),
-         'z', 13, 'i','I', 'm','M', 'k','K', 'l','L', 'n','N', KEY_ESC); //default answer 'z' is ignored
+         'z', 11, 'i','I', 'm','M', 'k','K', 'l','L', 'n','N', KEY_ESC); //default answer 'z' is ignored
 #endif
 
     if(Answer == 'i' || Answer == 'I'){


### PR DESCRIPTION
(UNIX) If the Save dir is not yet created, choosing "2. Continue Game" doesn't provide any notice.

btw, fix `character::ShowAdventureInfoAlt()`