### PR TITLE
Unlock chests that spawn broken locks

### DIFF
--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -1278,6 +1278,10 @@ void itemcontainer::PostConstruct()
 {
   lockableitem::PostConstruct();
   SetIsLocked(RAND_N(3));
+  
+  if((GetConfig()&LOCK_BITS)&BROKEN_LOCK)
+    SetIsLocked(false);
+  
   long ItemNumber = RAND() % (GetMaxGeneratedContainedItems() + 1);
 
   for(int c = 0; c < ItemNumber; ++c)


### PR DESCRIPTION
I noticed that chests with broken locks sometimes spawn locked. As there is no key to open a broken lock, I thought maybe they should be openable, meaning the player doesn't have to bash the broken lock open. 

Should chests with broken locks be jammed (current)? Or should they always be openable (this change)?

Doors can still spawn locked broken locks, and this change doesn't affect that behaviour.