### PR TITLE
(ready): Adjust naming scheme for save files

### DIFF
--- a/Main/Include/game.h
+++ b/Main/Include/game.h
@@ -494,7 +494,6 @@ class game
   static character* Player;
   static v2 Camera;
   static ulong Tick;
-  static festring* AutoSaveFileName;
   static truth InWilderness;
   static worldmap* WorldMap;
   static area* AreaInLoad;
@@ -558,6 +557,7 @@ class game
   static charactervector CharacterDrawVector;
   static truth SumoWrestling;
   static festring PlayerName;
+  static festring AutoSaveFileName;
   static liquid* GlobalRainLiquid;
   static v2 GlobalRainSpeed;
   static long GlobalRainTimeModifier;

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -184,6 +184,7 @@ truth game::GoThroughWallsCheat;
 int game::QuestMonstersFound;
 bitmap* game::BusyAnimationCache[32];
 festring game::PlayerName;
+festring game::AutoSaveFileName;
 ulong game::EquipmentMemory[MAX_EQUIPMENT_SLOTS];
 olterrain* game::MonsterPortal;
 std::vector<v2> game::SpecialCursorPos;
@@ -3106,25 +3107,40 @@ festring game::SaveName(cfestring& Base)
    * it will not be found if it gets changed...
    */
   festring BaseOk;
-  BaseOk << Base; DBG2(PlayerName.CStr(),Base.CStr());
 
-  if(Base.GetSize()==0){
-    BaseOk.Empty();
-    BaseOk << PlayerName; //ATTENTION! festring reuses the internal festring data pointer of other festring when using operator= even to char* !
+  DBG3(PlayerName.CStr(), Base.CStr(), AutoSaveFileName.CStr());
 
-    for(festring::sizetype c = 0; c < BaseOk.GetSize(); ++c){
-      // this prevents all possibly troublesome characters in all OSs
-      if(BaseOk[c]>=0x41 && BaseOk[c]<=0x5A)continue; //A-Z
-      if(BaseOk[c]>=0x61 && BaseOk[c]<=0x7A)continue; //a-z
-      if(BaseOk[c]>=0x30 && BaseOk[c]<=0x39)continue; //0-9
-
-      BaseOk[c] = '_';
+  if(Base.GetSize() > 0)
+  {
+    AutoSaveFileName.Empty();
+    AutoSaveFileName << Base;
+    BaseOk << Base;
+  }
+  else
+  {
+    if(AutoSaveFileName.GetSize() == 0)
+    {
+      AutoSaveFileName << PlayerName << '-' << time(0);  // e.g. PlayerName-1529392480
+  
+      for(festring::sizetype i = 0; i < AutoSaveFileName.GetSize(); ++i)
+      {
+        // this prevents all possibly troublesome characters in all OSs
+        if(AutoSaveFileName[i]>='A' && AutoSaveFileName[i]<='Z')continue;
+        if(AutoSaveFileName[i]>='a' && AutoSaveFileName[i]<='z')continue;
+        if(AutoSaveFileName[i]>='0' && AutoSaveFileName[i]<='9')continue;
+        if(AutoSaveFileName[i]=='-' || AutoSaveFileName[i]=='.')continue;
+  
+        AutoSaveFileName[i] = '_';
+      }
     }
-  }DBG3(PlayerName.CStr(),BaseOk.CStr(),Base.CStr());
+    BaseOk << AutoSaveFileName;
+  }
+
+  DBG4(PlayerName.CStr(), BaseOk.CStr(), Base.CStr(), AutoSaveFileName.CStr());
 
   SaveName << BaseOk;
 
-#if defined(WIN32) || defined(__DJGPP__)
+#if defined(__DJGPP__)
   if(SaveName.GetSize() > 13)
     SaveName.Resize(13);
 #endif

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -3106,15 +3106,13 @@ festring game::SaveName(cfestring& Base)
    * the problem on modifying it is that as it is read from the filesystem
    * it will not be found if it gets changed...
    */
-  festring BaseOk;
-
   DBG3(PlayerName.CStr(), Base.CStr(), AutoSaveFileName.CStr());
 
   if(Base.GetSize() > 0)
   {
     AutoSaveFileName.Empty();
     AutoSaveFileName << Base;
-    BaseOk << Base;
+    SaveName << Base;
   }
   else
   {
@@ -3132,12 +3130,10 @@ festring game::SaveName(cfestring& Base)
         AutoSaveFileName[i] = '_';
       }
     }
-    BaseOk << AutoSaveFileName;
+    SaveName << AutoSaveFileName;
   }
 
-  DBG4(PlayerName.CStr(), BaseOk.CStr(), Base.CStr(), AutoSaveFileName.CStr());
-
-  SaveName << BaseOk;
+  DBG4(PlayerName.CStr(), SaveName.CStr(), Base.CStr(), AutoSaveFileName.CStr());
 
 #if defined(__DJGPP__)
   if(SaveName.GetSize() > 13)

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -3120,7 +3120,7 @@ festring game::SaveName(cfestring& Base)
   {
     if(AutoSaveFileName.GetSize() == 0)
     {
-      AutoSaveFileName << PlayerName << '-' << time(0);  // e.g. PlayerName-1529392480
+      AutoSaveFileName << PlayerName << '_' << time(0);  // e.g. PlayerName-1529392480
   
       for(festring::sizetype i = 0; i < AutoSaveFileName.GetSize(); ++i)
       {
@@ -3128,7 +3128,6 @@ festring game::SaveName(cfestring& Base)
         if(AutoSaveFileName[i]>='A' && AutoSaveFileName[i]<='Z')continue;
         if(AutoSaveFileName[i]>='a' && AutoSaveFileName[i]<='z')continue;
         if(AutoSaveFileName[i]>='0' && AutoSaveFileName[i]<='9')continue;
-        if(AutoSaveFileName[i]=='-' || AutoSaveFileName[i]=='.')continue;
   
         AutoSaveFileName[i] = '_';
       }


### PR DESCRIPTION
ping #414

* lower the rate of duplicate filenames (I always use a fixed player name ;-)
* remove max length (13) of filenames on windows
* <del>allow dashes "-" and periods "." in player names</del>