### PR TITLE
Warn about spoiling food when consuming them

### DIFF
--- a/Main/Include/actions.h
+++ b/Main/Include/actions.h
@@ -48,12 +48,14 @@ ACTION(consume, action)
   virtual truth AllowFoodConsumption() const { return false; }
   virtual cchar* GetDescription() const;
   virtual void SetDescription(cfestring&);
-  virtual void SetNibbling(truth What) { nibbling = What; }
-  virtual truth IsNibbling() { return nibbling; }
+  virtual void SetNibbling(truth What) { Nibbling = What; }
+  virtual truth IsNibbling() { return Nibbling; }
  protected:
   festring Description;
   ulong ConsumingID;
-  truth nibbling = false;
+  truth Nibbling = false;
+  truth Gulping = false;
+  truth Spoiling = false;
 };
 
 ACTION(rest, action)

--- a/Main/Source/actions.cpp
+++ b/Main/Source/actions.cpp
@@ -83,14 +83,30 @@ void consume::Handle()
 
   character* Actor = GetActor();
 
-  if(!InDNDMode() && Actor->GetHungerState() >= BLOATED)
+  if(!Spoiling && Consuming->GetSpoilLevel() > 0)
+  {
+    if(Actor->IsPlayer())
+    {
+      ADD_MESSAGE("This thing is starting to get spoiled.");
+
+      if(game::TruthQuestion(CONST_S("Continue ") + GetDescription() + "? [y/N]"))
+        Spoiling = true;
+      else
+      {
+        Terminate(false);
+        return;
+      }
+    }
+  }
+
+  if(!Gulping && Actor->GetHungerState() >= BLOATED)
   {
     if(Actor->IsPlayer())
     {
       ADD_MESSAGE("You have a really hard time getting all this down your throat.");
 
       if(game::TruthQuestion(CONST_S("Continue ") + GetDescription() + "? [y/N]"))
-        ActivateInDNDMode();
+        Gulping = true;
       else
       {
         Terminate(false);


### PR DESCRIPTION
Also make ActivateInDNDMode() not called by actions themselves. This makes it easier to maintain the logic.

ping #463 