### PR TITLE
USE_HOME_FOR_STATE_DIR option added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,14 @@ set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 add_definitions(-DIVAN_VERSION="${PROJECT_VERSION}" -DUSE_SDL)
 
 option(BUILD_MAC_APP "Build standalone application for MacOS" OFF)
+option(USE_HOME_FOR_STATE_DIR "Statedir will be /.ivan/ in current user's homedir" OFF)
 
 if(UNIX)
   add_definitions(-DUNIX)
   include(GNUInstallDirs)
+  if(USE_HOME_FOR_STATE_DIR)
+    add_definitions(-DUSE_HOME_FOR_STATE_DIR)
+  endif(USE_HOME_FOR_STATE_DIR)
 
   if(BUILD_MAC_APP)
     install(DIRECTORY Graphics Script Music Sound DESTINATION "ivan")

--- a/INSTALL
+++ b/INSTALL
@@ -33,6 +33,9 @@ If config options toggle is too fast, you can add this flag '-DFELIST_WAITKEYUP'
 like this: CMAKE_CXX_FLAGS="-DFELIST_WAITKEYUP -DWIZARD" (you may chose what 
 flags to add independently of each other).
 
+To store score and bones' files at user $HOME/.ivan/ path, you can turn on cmake
+option 'USE_HOME_FOR_STATE_DIR', like this: "-DUSE_HOME_FOR_STATE_DIR=ON".
+
 --------------------------------------
 
 Under DOS:

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -5191,6 +5191,9 @@ festring game::GetDataDir()
 
 festring game::GetStateDir()
 {
+#ifdef USE_HOME_FOR_STATE_DIR
+  return GetHomeDir();
+#endif
 #ifdef UNIX
 #ifdef MAC_APP
   return GetHomeDir();


### PR DESCRIPTION
`USE_HOME_FOR_STATE_DIR` option was added to CMakeLists.txt.

Fully consistent with my pull request to [nixpkgs upstream](https://github.com/NixOS/nixpkgs/pull/47950).