### PR TITLE
Fix -Werror=format-security errors in FeLib

### DIFF
--- a/FeLib/Source/feio.cpp
+++ b/FeLib/Source/feio.cpp
@@ -89,7 +89,7 @@ void iosystem::TextScreen(cfestring& Text, v2 Disp,
       Line[c - LastBeginningOfLine] = 0;
       v2 PrintPos((RES.X >> 1) - (strlen(Line) << 2) + Disp.X,
                   (RES.Y << 1) / 5 - (LineNumber - Lines) * 15 + Disp.Y);
-      FONT->Printf(&Buffer, PrintPos, Color, Line);
+      FONT->Printf(&Buffer, PrintPos, Color, "%s", Line);
       ++Lines;
       LastBeginningOfLine = c + 1;
     }
@@ -99,7 +99,7 @@ void iosystem::TextScreen(cfestring& Text, v2 Disp,
   Line[c - LastBeginningOfLine] = 0;
   v2 PrintPos((RES.X >> 1) - (strlen(Line) << 2) + Disp.X,
               (RES.Y << 1) / 5 - (LineNumber - Lines) * 15 + Disp.Y);
-  FONT->Printf(&Buffer, PrintPos, Color, Line);
+  FONT->Printf(&Buffer, PrintPos, Color, "%s", Line);
 
   if(Fade)
     Buffer.FadeToScreen(BitmapEditor);

--- a/FeLib/Source/felist.cpp
+++ b/FeLib/Source/felist.cpp
@@ -1023,7 +1023,7 @@ void felist::DrawDescription(bitmap* Buffer) const
   {
     Buffer->Fill(Pos.X + 3, Pos.Y + 13 + c * 10, Width - 6, 10, BackColor);
     FONT->Printf(Buffer, v2(Pos.X + 13, Pos.Y + 13 + c * 10),
-                 Description[c]->Color, Description[c]->String.CStr());
+                 Description[c]->Color, "%s", Description[c]->String.CStr());
   }
 
   Buffer->Fill(Pos.X + 3, Pos.Y + 13 + Description.size() * 10,


### PR DESCRIPTION
Fixes the following GCC 8 errors:
```
/home/akien/tmp/ivan/BUILD/ivan-054/FeLib/Source/feio.cpp:92:46: error: format not a string literal and no format arguments [-Werror=format-security]
       FONT->Printf(&Buffer, PrintPos, Color, Line);
                                              ^~~~
/home/akien/tmp/ivan/BUILD/ivan-054/FeLib/Source/feio.cpp:102:42: error: format not a string literal and no format arguments [-Werror=format-security]
   FONT->Printf(&Buffer, PrintPos, Color, Line);
                                          ^~~~
/home/akien/tmp/ivan/BUILD/ivan-054/FeLib/Source/felist.cpp:1026:70: error: format not a string literal and no format arguments [-Werror=format-security]
                  Description[c]->Color, Description[c]->String.CStr());
                                                                      ^
```

I'm packaging IVAN for the Mageia Linux distro, and we use those CXXFLAGS by default: `-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables`.
