### PR TITLE
game::GetHomeDir() and game::GetStateDir() were merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,10 @@ set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 add_definitions(-DIVAN_VERSION="${PROJECT_VERSION}" -DUSE_SDL)
 
 option(BUILD_MAC_APP "Build standalone application for MacOS" OFF)
-option(USE_HOME_FOR_STATE_DIR "Statedir will be /.ivan/ in current user's homedir" OFF)
 
 if(UNIX)
   add_definitions(-DUNIX)
   include(GNUInstallDirs)
-  if(USE_HOME_FOR_STATE_DIR)
-    add_definitions(-DUSE_HOME_FOR_STATE_DIR)
-  endif(USE_HOME_FOR_STATE_DIR)
 
   if(BUILD_MAC_APP)
     install(DIRECTORY Graphics Script Music Sound DESTINATION "ivan")
@@ -28,8 +24,7 @@ if(UNIX)
     add_definitions(-DMAC_APP)
   else()
     install(DIRECTORY Graphics Script Music Sound DESTINATION "${CMAKE_INSTALL_DATADIR}/ivan")
-    add_definitions(-DDATADIR="${CMAKE_INSTALL_FULL_DATADIR}"
-                    -DLOCAL_STATE_DIR="${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/ivan")
+    add_definitions(-DDATADIR="${CMAKE_INSTALL_FULL_DATADIR}")
   endif()
 
 elseif(WIN32)

--- a/INSTALL
+++ b/INSTALL
@@ -33,9 +33,6 @@ If config options toggle is too fast, you can add this flag '-DFELIST_WAITKEYUP'
 like this: CMAKE_CXX_FLAGS="-DFELIST_WAITKEYUP -DWIZARD" (you may chose what 
 flags to add independently of each other).
 
-To store score and bones' files at user $HOME/.ivan/ path, you can turn on cmake
-option 'USE_HOME_FOR_STATE_DIR', like this: "-DUSE_HOME_FOR_STATE_DIR=ON".
-
 --------------------------------------
 
 Under DOS:

--- a/Main/Include/game.h
+++ b/Main/Include/game.h
@@ -348,7 +348,6 @@ class game
   static void SetXinrochTombStoryState(int What) { XinrochTombStoryState = What; }
   static void SetIsInGetCommand(truth What) { InGetCommand = What; }
   static truth IsInGetCommand() { return InGetCommand; }
-  static festring GetHomeDir();
   static festring GetSaveDir();
   static festring GetScrshotDir();
   static festring GetDataDir();

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -2162,8 +2162,8 @@ truth commandsystem::SecretKnowledge(character* Char)
       delete Material[c];
   }
 
-  List.PrintToFile(game::GetHomeDir() + "secret" + Chosen + ".txt");
-  ADD_MESSAGE("Info written also to %ssecret%d.txt.", game::GetHomeDir().CStr(), Chosen);
+  List.PrintToFile(game::GetStateDir() + "secret" + Chosen + ".txt");
+  ADD_MESSAGE("Info written also to %ssecret%d.txt.", game::GetStateDir().CStr(), Chosen);
   return false;
 }
 

--- a/Main/Source/definesvalidator.cpp
+++ b/Main/Source/definesvalidator.cpp
@@ -36,7 +36,7 @@ void DefinesValidatorAppend(std::string s)
 
   static bool bDummyInit = [](){
     DefinesValidator.open(
-        festring(game::GetHomeDir() + "definesvalidator.h").CStr(),
+        festring(game::GetStateDir() + "definesvalidator.h").CStr(),
         std::ios::binary);
     return true;}();
 

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -733,7 +733,7 @@ truth game::Init(cfestring& loadBaseName)
 #endif
 
 #ifdef UNIX
-  mkdir(GetHomeDir().CStr(), S_IRWXU|S_IRWXG);
+  mkdir(GetStateDir().CStr(), S_IRWXU|S_IRWXG);
   mkdir(GetSaveDir().CStr(), S_IRWXU|S_IRWXG);
   mkdir(GetBoneDir().CStr(), S_IRWXU|S_IRWXG);
 #endif
@@ -5143,7 +5143,7 @@ inputfile& operator>>(inputfile& SaveFile, dangerid& Value)
 
 /* The program can only create directories to the deepness of one, no more... */
 
-festring game::GetHomeDir()
+festring game::GetStateDir()
 {
 #ifdef UNIX
   festring Dir;
@@ -5160,18 +5160,18 @@ festring game::GetHomeDir()
 #endif
 
 #if defined(WIN32) || defined(__DJGPP__)
-  return "";
+  return "./";
 #endif
 }
 
 festring game::GetSaveDir()
 {
-  return GetHomeDir() + "Save/";
+  return GetStateDir() + "Save/";
 }
 
 festring game::GetScrshotDir()
 {
-  return GetHomeDir() + "Scrshot/";
+  return GetStateDir() + "Scrshot/";
 }
 
 festring game::GetDataDir()
@@ -5185,25 +5185,7 @@ festring game::GetDataDir()
 #endif
 
 #if defined(WIN32) || defined(__DJGPP__)
-  return GetHomeDir();
-#endif
-}
-
-festring game::GetStateDir()
-{
-#ifdef USE_HOME_FOR_STATE_DIR
-  return GetHomeDir();
-#endif
-#ifdef UNIX
-#ifdef MAC_APP
-  return GetHomeDir();
-#else
-  return LOCAL_STATE_DIR "/";
-#endif
-#endif
-
-#if defined(WIN32) || defined(__DJGPP__)
-  return GetHomeDir();
+  return GetStateDir();
 #endif
 }
 

--- a/Main/Source/iconf.cpp
+++ b/Main/Source/iconf.cpp
@@ -1014,9 +1014,9 @@ void ivanconfig::Initialize()
    * LOAD AND APPLY some SETTINGS *
    ********************************/
 #if defined(WIN32) || defined(__DJGPP__)
-  configsystem::SetConfigFileName(game::GetHomeDir() + "ivan.cfg");
+  configsystem::SetConfigFileName(game::GetStateDir() + "ivan.cfg");
 #else
-  configsystem::SetConfigFileName(game::GetHomeDir() + "ivan.conf");
+  configsystem::SetConfigFileName(game::GetStateDir() + "ivan.conf");
 #endif
 
   configsystem::Load();

--- a/Main/Source/main.cpp
+++ b/Main/Source/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
   signal(SIGQUIT, CrashHandler);
 #endif
 
-  game::GetHomeDir(); //just to properly initialize as soon as possible DBGMSG correct path b4 everywhere it may be used.
+  game::GetStateDir(); //just to properly initialize as soon as possible DBGMSG correct path b4 everywhere it may be used.
 
   if(argc > 1 && festring(argv[1]) == "--version")
   {

--- a/Main/Source/message.cpp
+++ b/Main/Source/message.cpp
@@ -334,7 +334,7 @@ void soundsystem::initSound()
 
   if(SoundState == 0)
   {
-    festring fsSndDbgFile=game::GetHomeDir()+"/"+"ivanSndDebug.txt";
+    festring fsSndDbgFile=game::GetStateDir()+"ivanSndDebug.txt";
     FILE *debf = fopen(fsSndDbgFile.CStr(), "wt"); //"a");
     if(debf)fprintf(debf, "This file can be used to diagnose problems with sound.\n");
 


### PR DESCRIPTION
Original `game::GetStateDir()` was deleted, `game::GetHomeDir()` was renamed to `game::GetStateDir()`, all calls are replaced accordingly.
`-DLOCAL_STATE_DIR="${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/ivan"` definition and `USE_HOME_FOR_STATE_DIR` option have been removed from **CMakeLists.txt** as unnecessary.
@iology New pull request corresponding to your initiative! :alien: 