### PR TITLE
Backtrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_definitions(-DIVAN_VERSION="${PROJECT_VERSION}" -DUSE_SDL)
 
 option(BUILD_MAC_APP "Build standalone application for MacOS" OFF)
 option(USE_HOME_FOR_STATE_DIR "Statedir will be /.ivan/ in current user's homedir" OFF)
+option(WIZARD "Enable Wizard Mode" OFF)
 
 if(UNIX)
   add_definitions(-DUNIX)
@@ -51,6 +52,15 @@ elseif(WIN32)
   # Switching to std::chrono should not be hard, but it's not a topic for this pull request.
   add_definitions(-D_USE_32BIT_TIME_T)
 endif(UNIX)
+
+if(WIZARD)
+  add_definitions(-DWIZARD)
+endif()
+
+find_path(EXECINFO_INCLUDE_DIR NAMES execinfo.h)
+if(NOT EXECINFO_INCLUDE_DIR MATCHES "-NOTFOUND$")
+  add_definitions(-DBACKTRACE)
+endif()
 
 add_subdirectory(FeLib)
 add_subdirectory(audio)

--- a/FeLib/Source/error.cpp
+++ b/FeLib/Source/error.cpp
@@ -21,6 +21,10 @@
 #include "graphics.h"
 #endif
 
+#ifdef BACKTRACE
+#include <execinfo.h>
+#endif
+
 #ifdef WIN32
 #include "SDL.h"
 #include <windows.h>
@@ -29,7 +33,6 @@
 #include <csignal>
 #include <cstring>
 #include <cstdlib>
-#include <execinfo.h>
 #include <unistd.h>
 #endif
 
@@ -65,7 +68,7 @@ int globalerrorhandler::Signal[SIGNALS]
 = { SIGABRT, SIGFPE, SIGILL, SIGSEGV, SIGTERM, SIGINT, SIGKILL, SIGQUIT };
 #endif
 
-#ifndef WIN32
+#ifdef BACKTRACE
 void globalerrorhandler::DumpStackTraceToStdErr(int Signal){
   // Prints stack trace to stderr.
   void* CallStack[128];
@@ -105,7 +108,7 @@ void globalerrorhandler::DeInstall()
 
 void globalerrorhandler::Abort(cchar* Format, ...)
 {
-#ifndef WIN32
+#ifdef BACKTRACE
   DumpStackTraceToStdErr();
 #endif
 

--- a/INSTALL
+++ b/INSTALL
@@ -9,6 +9,7 @@ installed on your system:
 - SDL (https://www.libsdl.org) version 1.2 or newer, at least 2.0 recommended
 - libpng (http://www.libpng.org/pub/png/libpng.html)
 - pcre, not pcre2 (ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/)
+- glibc if backtrace support is enabled (https://www.gnu.org/software/libc/)
 
 --------------------------------------
 
@@ -18,9 +19,9 @@ cmake .
 make -j
 make install
 
-Note: Wizard Mode is disabled by default. To enable it run:
+Note: Wizard Mode and backtrace are disabled by default. To enable it run:
 
-cmake -D CMAKE_CXX_FLAGS="-DWIZARD" .
+cmake -D CMAKE_CXX_FLAGS="-DWIZARD -DBACKTRACE" .
 make -j
 make install
 

--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,6 @@ installed on your system:
 - SDL (https://www.libsdl.org) version 1.2 or newer, at least 2.0 recommended
 - libpng (http://www.libpng.org/pub/png/libpng.html)
 - pcre, not pcre2 (ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/)
-- glibc if backtrace support is enabled (https://www.gnu.org/software/libc/)
 
 --------------------------------------
 
@@ -19,9 +18,9 @@ cmake .
 make -j
 make install
 
-Note: Wizard Mode and backtrace are disabled by default. To enable it run:
+Note: Wizard Mode is disabled by default. To enable it run:
 
-cmake -D CMAKE_CXX_FLAGS="-DWIZARD -DBACKTRACE" .
+cmake -DWIZARD=ON .
 make -j
 make install
 
@@ -30,9 +29,8 @@ To install IVAN to a custom prefix, pass the additional flag
 (In particular, simply doing `make DESTDIR=/your/prefix/path install`
 doesn't work because IVAN needs the prefix information at build-time.)
 
-If config options toggle is too fast, you can add this flag '-DFELIST_WAITKEYUP', 
-like this: CMAKE_CXX_FLAGS="-DFELIST_WAITKEYUP -DWIZARD" (you may chose what 
-flags to add independently of each other).
+If config options toggle is too fast, you can add this flag '-DFELIST_WAITKEYUP',
+like this: CMAKE_CXX_FLAGS="-DFELIST_WAITKEYUP"
 
 --------------------------------------
 

--- a/Main/Source/main.cpp
+++ b/Main/Source/main.cpp
@@ -17,11 +17,14 @@
 #include <sys/farptr.h>
 #endif
 
+#ifdef BACKTRACE
+#include <execinfo.h>
+#endif
+
 #ifndef WIN32
 #include <csignal>
 #include <cstring>
 #include <cstdlib>
-#include <execinfo.h>
 #include <unistd.h>
 #endif
 
@@ -45,7 +48,7 @@
 
 #include "bugworkaround.h"
 
-#ifndef WIN32
+#ifdef BACKTRACE
 void CrashHandler(int Signal)
 {
   globalerrorhandler::DumpStackTraceToStdErr(Signal);
@@ -60,7 +63,7 @@ void SkipGameScript(inputfile* pSaveFile){
 
 int main(int argc, char** argv)
 {
-#ifndef WIN32
+#ifdef BACKTRACE
   signal(SIGABRT, CrashHandler);
   signal(SIGBUS, CrashHandler);
   signal(SIGFPE, CrashHandler);


### PR DESCRIPTION
closes https://github.com/Attnam/ivan/issues/491

The current backtrace function is glibc-specific so it will only work on specific GNU/Linux and GNU/Hurd systems. This PR moves the glibc-specific backtrace to a compile-time flag. 

I successfully compiled and played ivan on a musl libc Linux system with these patches.