### PR TITLE
Remove googlegroups mailing list

### DIFF
--- a/FeLib/Source/error.cpp
+++ b/FeLib/Source/error.cpp
@@ -51,10 +51,9 @@
 /* Shouldn't be initialized here! */
 
 cchar* globalerrorhandler::BugMsg
-= "\n\nPlease send bug report to ivan-support@googlegroups.com\n"
+= "\n\nPlease submit a bug report on our forum at http://attnam.com\n"
 "including a brief description of what you did, what version\n"
-"you are running and which kind of system you are using.\n"
-"Or submit on our forum at http://attnam.com";
+"you are running and which kind of system you are using.";
 
 #ifdef VC
 int (*globalerrorhandler::OldNewHandler)(size_t) = 0;

--- a/README
+++ b/README
@@ -179,9 +179,7 @@ Q: I am a DOS user. When I try to run IVAN, I get the message "Load error:
 Q: I've found a bug. What should I do?
 
 A: Write a small description on how the bug occurred and if possible even
-   how we could replicate it, and send this information by email to
-   ivan-support@googlegroups.com. You can also report this bug on our
-   forum:
+   how we could replicate it, and post this information on our forum:
 
    http://attnam.com
 
@@ -190,8 +188,7 @@ A: Write a small description on how the bug occurred and if possible even
 
 Q: I've got a great idea to make IVAN better! What should I do?
 
-A: Describe the idea to us by sending it to ivan-support@googlegroups.com
-   or report it on our forum (see above). You will be credited if we
+A: Post the idea on our forum (see above). You will be credited if we
    implement the feature, it's non-trivial, and you're first to suggest it.
 
 Q: I'm a programmer willing to help you. What should I do?

--- a/README.md
+++ b/README.md
@@ -157,9 +157,7 @@ Score = sqrt(a) * b * b
 
 **Q:** I've found a bug. What should I do?  
 **A:** Write a small description on how the bug occurred and if possible even
-   how we could replicate it, and send this information by email to
-   ivan-support@googlegroups.com. You can also report this bug on our
-   forum:
+   how we could replicate it, and post this information on our forum:
 
    http://attnam.com
 
@@ -167,8 +165,7 @@ Score = sqrt(a) * b * b
    AUTHORS file, if you are the first to discover this bug.
 
 **Q:** I've got a great idea to make IVAN better! What should I do?  
-**A:** Describe the idea to us by sending it to ivan-support@googlegroups.com
-   or report it on our forum (see above). You will be credited if we
+**A:** Post the idea on our forum (see above). You will be credited if we
    implement the feature, it's non-trivial, and you're first to suggest it.
 
 **Q:** I'm a programmer willing to help you. What should I do?  


### PR DESCRIPTION
I think we should deprecate the googlegroups mailing list (https://groups.google.com/forum/#!forum/ivan-support) because almost nobody is using it.

Only two bug reports have been sent there, one in 2016 and one yesterday. And the one posted yesterday was also submitted to attnam.com.

