### PR TITLE
Improve path search for SDL2

### DIFF
--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -65,23 +65,25 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
+# Caveat: If you want to find standard libraries or headers before frameworks,
+#         you must pass -DCMAKE_FIND_FRAMEWORK=LAST to cmake.
 SET(SDL2_SEARCH_PATHS
 	# other paths like ~/Library/Frameworks and /usr/local
-	# should be provided by $ENV{SDL2DIR}
+	# should be provided/prioritized by setting $ENV{SDL2DIR}
 	/Library/Frameworks
 	/usr
 )
 
 # CPU architecture detection for MSVC
 if(CMAKE_SIZEOF_VOID_P MATCHES 8)
-    set(CPU_ARCH "x64")
+	set(CPU_ARCH "x64")
 else()
-    set(CPU_ARCH "x86")
+	set(CPU_ARCH "x86")
 endif()
 
 FIND_PATH(SDL2_INCLUDE_DIR
 	NAMES SDL.h
-	PATH_SUFFIXES include/SDL2 include
+	PATH_SUFFIXES include/SDL2 SDL2 include
 	PATHS $ENV{SDL2DIR} ${SDL2_SEARCH_PATHS}
 )
 
@@ -93,7 +95,7 @@ FIND_LIBRARY(SDL2_LIBRARY_TEMP
 
 FIND_PATH(SDL2_mixer_INCLUDE_DIR
 	NAMES SDL_mixer.h
-	PATH_SUFFIXES include/SDL2 include
+	PATH_SUFFIXES include/SDL2 SDL2 include
 	PATHS $ENV{SDL2DIR} ${SDL2_SEARCH_PATHS}
 )
 

--- a/xbrzscale/libxbrzscale.cpp
+++ b/xbrzscale/libxbrzscale.cpp
@@ -22,10 +22,10 @@
 #include <iostream>
 
 #ifndef XBRZLIB_RELATIVEPATHSDL
-#include <SDL2/SDL_endian.h>
-#include <SDL2/SDL_error.h>
-#include <SDL2/SDL_pixels.h>
-#include <SDL2/SDL_surface.h>
+#include <SDL_endian.h>
+#include <SDL_error.h>
+#include <SDL_pixels.h>
+#include <SDL_surface.h>
 #else
 #include "SDL_endian.h"
 #include "SDL_error.h"

--- a/xbrzscale/libxbrzscale.h
+++ b/xbrzscale/libxbrzscale.h
@@ -17,7 +17,7 @@
  */
 
 #ifndef XBRZLIB_RELATIVEPATHSDL
-#include <SDL2/SDL_stdinc.h>
+#include <SDL_stdinc.h>
 #else
 #include "SDL_stdinc.h"
 #endif

--- a/xbrzscale/xbrzscale.cpp.DISABLED
+++ b/xbrzscale/xbrzscale.cpp.DISABLED
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_error.h>
-#include <SDL2/SDL_image.h>
-#include <SDL2/SDL_main.h>
-#include <SDL2/SDL_surface.h>
+#include <SDL.h>
+#include <SDL_error.h>
+#include <SDL_image.h>
+#include <SDL_main.h>
+#include <SDL_surface.h>
 #include <cstdio>
 #include <cstdlib>
 
@@ -73,21 +73,21 @@ int main(int argc, char* argv[]) {
 		fprintf(stderr, "scale_factor can be between 2 and 6\n");
 		return 1;
 	}
-	
+
 	int scale = atoi(argv[1]);
 	char* in_file = argv[2];
 	char* out_file = argv[3];
-	
+
 	if (scale < 2 || scale > 6) {
 		fprintf(stderr, "scale_factor must be between 2 and 6 (inclusive), got %i\n", scale);
 		return 1;
 	}
-	
+
 	if (SDL_Init(SDL_INIT_VIDEO) != 0) {
 		fprintf(stderr, "Failed to initialize SDL: %s\n", SDL_GetError());
 		return 1;
 	}
-	
+
 	SDL_Surface* src_img = IMG_Load(in_file);
   if (!src_img) {
     fprintf(stderr, "Failed to load source image '%s': %s\n", in_file, IMG_GetError());


### PR DESCRIPTION
This should resolve #498 if both SDL1 and SDL2 exist and their include paths are `/prefix/include` (not `/prefix/include/SDL`) and `/prefix/include/SDL2`.
