### PR TITLE
Fix ring detection to work same as scrolls

### DIFF
--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -4768,7 +4768,7 @@ void character::DoDetecting()
         continue;
     }
 
-    TempMaterial = protosystem::CreateMaterial(Temp);
+    TempMaterial = protosystem::CreateMaterialForDetection(Temp);
 
     if(TempMaterial)
       break;


### PR DESCRIPTION
Scroll of detect material was fixed to be able to detect carrot, etc. but the ring of detection was still forbidding those materials. 