### PR TITLE
Don't drop containers after tasting unless empty

### DIFF
--- a/Main/Source/actions.cpp
+++ b/Main/Source/actions.cpp
@@ -161,7 +161,15 @@ void consume::Terminate(truth Finished)
 
   if(Finished)
   {
-    if(Consuming->Exists() && !game::IsInWilderness() && (!Actor->IsPlayer() || ivanconfig::GetAutoDropLeftOvers()))
+    truth PlayerWantsToDiscard = false;
+    if(Consuming->GetSecondaryMaterial()){
+      PlayerWantsToDiscard = (
+        ivanconfig::GetAutoDropLeftOvers() &&
+        (Consuming->GetSecondaryMaterial()->GetVolume() == 0) // don't drop after tasting
+      );
+    }
+
+    if(Consuming->Exists() && !game::IsInWilderness() && (!Actor->IsPlayer() || PlayerWantsToDiscard))
     {
       Consuming->RemoveFromSlot();
       Actor->GetStackUnder()->AddItem(Consuming);

--- a/Main/Source/actions.cpp
+++ b/Main/Source/actions.cpp
@@ -161,19 +161,23 @@ void consume::Terminate(truth Finished)
 
   if(Finished)
   {
-    truth PlayerWantsToDiscard = ivanconfig::GetAutoDropLeftOvers();
-    if(Consuming->GetSecondaryMaterial()){
-      PlayerWantsToDiscard = (
-        ivanconfig::GetAutoDropLeftOvers() &&
-        (Consuming->GetSecondaryMaterial()->GetVolume() == 0) // don't drop after tasting
-      );
-    }
-
-    if(Consuming->Exists() && !game::IsInWilderness() && (!Actor->IsPlayer() || PlayerWantsToDiscard))
+    if(Consuming && Consuming->Exists())
     {
-      Consuming->RemoveFromSlot();
-      Actor->GetStackUnder()->AddItem(Consuming);
-      Actor->DexterityAction(2);
+      truth PlayerWantsToDiscard = ivanconfig::GetAutoDropLeftOvers();
+      if(Consuming->GetSecondaryMaterial())
+      {
+        PlayerWantsToDiscard = (
+          ivanconfig::GetAutoDropLeftOvers() &&
+          (Consuming->GetSecondaryMaterial()->GetVolume() == 0) // don't drop after tasting
+        );
+      }
+
+      if(!game::IsInWilderness() && (!Actor->IsPlayer() || PlayerWantsToDiscard))
+      {
+        Consuming->RemoveFromSlot();
+        Actor->GetStackUnder()->AddItem(Consuming);
+        Actor->DexterityAction(2);
+      }
     }
   }
   else if(Consuming && Consuming->Exists())

--- a/Main/Source/actions.cpp
+++ b/Main/Source/actions.cpp
@@ -161,7 +161,7 @@ void consume::Terminate(truth Finished)
 
   if(Finished)
   {
-    truth PlayerWantsToDiscard = false;
+    truth PlayerWantsToDiscard = ivanconfig::GetAutoDropLeftOvers();
     if(Consuming->GetSecondaryMaterial()){
       PlayerWantsToDiscard = (
         ivanconfig::GetAutoDropLeftOvers() &&


### PR DESCRIPTION
Might fix #545. My SDL is broken so I can't compile and test yet.