### PR TITLE
Create hidden window first, then show the window

### DIFF
--- a/FeLib/Source/graphics.cpp
+++ b/FeLib/Source/graphics.cpp
@@ -203,7 +203,7 @@ void graphics::SetMode(cchar* Title, cchar* IconName,
 
   SDL_WM_SetCaption(Title, 0);
 #else
-  Flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+  Flags |= SDL_WINDOW_ALLOW_HIGHDPI|SDL_WINDOW_HIDDEN;
 
   Window = SDL_CreateWindow(Title,
                             SDL_WINDOWPOS_UNDEFINED,

--- a/FeLib/Source/whandler.cpp
+++ b/FeLib/Source/whandler.cpp
@@ -150,6 +150,7 @@ void globalwindowhandler::Init()
   SDL_EnableKeyRepeat(500, 30);
 #else
   //FIXSDL2 SDL_EnableKeyRepeat(500, 30);
+  SDL_ShowWindow(graphics::GetWindow());
 #endif
 }
 


### PR DESCRIPTION
Fixes a bug reported on the Attnam forums: https://attnam.com/posts/29912

Possibly also alleviates #535

This bug arose in changes made between SDL2 2.0.8 and 2.0.9, specifically:  https://hg.libsdl.org/SDL/diff/fbfacc66c65c/src/video/windows/SDL_windowsevents.c