### PR TITLE
Nerf magic helmets

### DIFF
--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -484,8 +484,9 @@ cchar* character::GetNormalDeathMessage() const
     "done in @k", "defeated @k", "struck down @k", "offed @k", "mowed down @k",
     "taken down @k", "sent to the grave @k", "destroyed @k", "executed @k",
     "slaughtered @k", "annihilated @k", "finished @k", "neutralized @k",
-    "obliterated @k", "snuffed @k", "done away with @k", "put to death @k" };
-  return killed_by[RAND() % 27];
+    "obliterated @k", "snuffed @k", "done away with @k", "put to death @k",
+    "released of this mortal coil @k", "taken apart @k", "unmade @k" };
+  return killed_by[RAND() % 30];
 }
 
 festring character::GetGhostDescription() const

--- a/Script/item.dat
+++ b/Script/item.dat
@@ -5135,7 +5135,6 @@ helmet
                               25, 10, 5, 2, 1, 25, 5; }
     HelmetBitmapPos = 112, 496;
     EnchantmentPlusChance = 30;
-    SoundResistance = 0;
   }
 
   Config FULL_HELMET;
@@ -5184,105 +5183,69 @@ helmet
 
   Config HELM_OF_PERCEPTION;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 1;
-    NameSingular = "helmet";
-    FlexibleNameSingular = "cap";
     PostFix = "of piercing perception";
     AffectsPerception = true;
-    MainMaterialConfig == ILLITHIUM;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
     AttachedGod = LEGIFER;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
-    SoundResistance = 1;
     Alias = { 2, "helm of perception", "perception"; }
   }
 
   Config BROKEN|HELM_OF_PERCEPTION;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 2;
     Price = 25;
     AffectsPerception = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
   Config HELM_OF_UNDERSTANDING;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 1;
-    NameSingular = "helmet";
-    FlexibleNameSingular = "cap";
     PostFix = "of understanding";
     AffectsWisdom = true;
-    MainMaterialConfig == UNICORN_HORN;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
     AttachedGod = SOPHOS;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
-    SoundResistance = 1;
     Alias = { 2, "helm of wisdom", "wisdom"; }
   }
 
   Config BROKEN|HELM_OF_UNDERSTANDING;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 2;
     Price = 25;
     AffectsWisdom = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
   Config HELM_OF_BRILLIANCE;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 1;
-    NameSingular = "helmet";
-    FlexibleNameSingular = "cap";
     PostFix = "of brilliance";
     AffectsIntelligence = true;
-    MainMaterialConfig == ARCANITE;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
-    SoundResistance = 1;
     Alias = { 2, "helm of intelligence", "intelligence"; }
   }
 
   Config BROKEN|HELM_OF_BRILLIANCE;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 2;
     Price = 25;
     AffectsIntelligence = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
@@ -5295,11 +5258,26 @@ helmet
     BitmapPos = 48, 32;
     Possibility = 5;
     NameSingular = "helmet";
-    FlexibleNameSingular = "cap";
+    FlexibleNameSingular = "helmet"; /* using full helmet graphics */
     PostFix = "of attractivity";
     AffectsCharisma = true;
-    MainMaterialConfig == GOLD;
-    MaterialConfigChances == 100;
+    MainMaterialConfig = { 60,
+                           SILVER, MOON_SILVER, GOLD, DARK_GOLD, PLATINUM, ELECTRUM,
+                           TITANITE, ADAMANT, CHAR_COAL, COAL, JET, URANIUM, SOLARIUM,
+                           NEUTRONIUM, MAGIC_CRYSTAL, BLUE_CRYSTAL, GREEN_CRYSTAL,
+                           PURPLE_CRYSTAL, PEARL_GLASS, PETRIFIED_WOOD, PETRIFIED_DARK,
+                           DRAGON_BONE, MAMMOTH_TUSK, OBSIDIAN, JASPER, JACINTH, AGATE,
+                           TOURMALINE, CHALCEDONY, CITRINE, LAPIS_LAZULI, OCCULTUM,
+                           AMBER, OPAL, ONYX, PEARL, CORAL, ROSE_QUARTZ, NETHER_QUARTZ,
+                           AMETHYST, TOPAZ, SAPPHIRE, EMERALD, RUBY, DIAMOND, BLACK_DIAMOND,
+                           JADEITE, MALACHITE, NEPHRITE, BLACK_JADE, RED_JADE, GREEN_JADE,
+                           BLUE_JADE, WHITE_JADE, BRIM_STONE, ALABASTER, HEMATITE,
+                           PYRITE, PRIMORDIAL_ICE, HALCYON; }
+    MaterialConfigChances = { 60,
+                              300, 25, 200, 25, 50, 75, 5, 5, 10, 10, 25, 1, 1, 1,
+                              5, 5, 5, 5, 3, 2, 1, 1, 25, 50, 75, 50, 50, 50, 50, 50,
+                              50, 5, 75, 75, 75, 50, 25, 25, 25, 50, 50, 50, 50, 50,
+                              25, 5, 50, 50, 50, 25, 20, 15, 10, 5, 2, 1, 2, 5, 1, 1; }
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
@@ -5354,99 +5332,66 @@ helmet
 
   Config HELM_OF_WILLPOWER;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 1;
-    NameSingular = "helmet";
-    FlexibleNameSingular = "cap";
     PostFix = "of indomitable will";
     AffectsWillPower = true;
-    MainMaterialConfig == OCTIRON;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
     AttachedGod = LEGIFER;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
     Alias = { 3, "helm of willpower", "willpower", "will"; }
   }
 
   Config BROKEN|HELM_OF_WILLPOWER;
   {
-    BitmapPos = 64, 32;
-    Possibility = 0;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
+    Possibility = 1;
     Price = 25;
     AffectsWillPower = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
   Config HELM_OF_TELEPATHY;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 5;
-    NameSingular = "helmet";
-    FlexibleNameSingular = "cap";
     PostFix = "of telepathy";
     GearStates = ESP;
-    MainMaterialConfig == SOUL_STEEL;
-    MaterialConfigChances == 100;
     Price = 100;
     AttachedGod = INFUSCOR;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
     Alias == "helm of ESP";
   }
 
   Config BROKEN|HELM_OF_TELEPATHY;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 3;
     Price = 25;
     GearStates = 0;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
   Config HELM_OF_TELEPORTATION;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 5;
-    NameSingular = "helmet";
-    FlexibleNameSingular = "cap";
     PostFix = "of teleportation";
     GearStates = TELEPORT;
-    MainMaterialConfig == MITHRIL;
-    MaterialConfigChances == 100;
     Price = 100;
     AttachedGod = SOPHOS;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
     Alias == "helm of teleport";
   }
 
   Config BROKEN|HELM_OF_TELEPORTATION;
   {
-    BitmapPos = 64, 32;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
     Possibility = 3;
     Price = 25;
     GearStates = 0;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 
@@ -5480,6 +5425,7 @@ helmet
     CoverPercentile = 90;
     HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
+    SoundResistance = 1;
     GearStates = INFRA_VISION|SEARCHING;
   }
 
@@ -5496,35 +5442,24 @@ helmet
 
   Config HELM_OF_MANA;
   {
-    DefaultSize = 40;
-    DefaultMainVolume = 250;
-    StrengthModifier = 125;
-    FormModifier = 25;
-    BitmapPos = 48, 32;
     Possibility = 1;
-    NameSingular = "helmet";
-    FlexibleNameSingular = "cap";
     PostFix = "of essence plethora";
     Alias == "helm of mana";
     AffectsMana = true;
-    MainMaterialConfig == AMETHYST;
-    MaterialConfigChances == 100;
     BaseEnchantment = 1;
     Price = 100;
     PriceIsProportionalToEnchantment = true;
     AttachedGod = SOPHOS;
-    CoverPercentile = 90;
-    HelmetBitmapPos = 96, 432;
     EnchantmentPlusChance = 2;
   }
 
   Config BROKEN|HELM_OF_MANA;
   {
-    BitmapPos = 64, 32;
-    Possibility = 0;
+    BitmapPos = 64, 64;
+    HelmetBitmapPos = 112, 496;
+    Possibility = 1;
     Price = 25;
     AffectsMana = false;
-    HelmetBitmapPos = 96, 512;
     EnchantmentPlusChance = 4;
   }
 


### PR DESCRIPTION
Magic helmets with pre-defined materials are too strong, as they appear 
early with good material AND a magical effect.

Make magic helmets use randomized materials. Their magic effects should 
be good enough to make them competitive with other helmets.

Also switch most magic helmets to normal helmet, rather than full 
helmet. This allows full helmets to be more distinct, as they will offer 
the best coverage and AV.