### PR TITLE
Do not aggressively upgrade dependencies for mac build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ addons:
       - libsdl2-mixer-dev
 
 before_install:
+  - export HOMEBREW_NO_AUTO_UPDATE=1
   - export IVAN_BUILD_DIR=${TRAVIS_BUILD_DIR}/build
   - export IVAN_FILE_VERSION=${TRAVIS_TAG#v}
   - if [[ "$TRAVIS_OS_NAME" = osx ]]; then ./ci/osx/requirements.sh; fi

--- a/ci/osx/requirements.sh
+++ b/ci/osx/requirements.sh
@@ -12,7 +12,7 @@ brew_install() {
   for dep in "$@"; do
     if brew list "${dep}" &>/dev/null; then
       if [[ -n "${IVAN_PLATFORM}" || "${BUILD_MAC_APP}" = ON ]]; then
-        brew upgrade "${dep}" || true  # error for "already installed" is so annoying
+        : brew upgrade "${dep}" || true  # error for "already installed" is so annoying
       fi
     else
       brew install "${dep}"

--- a/ci/osx/requirements.sh
+++ b/ci/osx/requirements.sh
@@ -49,9 +49,10 @@ install_sdl2() {
   ls -hl "${CACHE_DIR}"
 }
 
-brew update
-
 if [[ -n "${IVAN_PLATFORM}" || "${BUILD_MAC_APP}" = ON ]]; then
+  if [[ -n "${TRAVIS_TAG}" ]]; then
+    brew update  # for deployment
+  fi
   brew_install pkg-config cmake pcre libpng
   install_sdl2
 else


### PR DESCRIPTION
* that would slow down the build
* that might upgrade dependents we don't care
* the preinstalled dependencies are quite stable

ping #558
