### PR TITLE
Further Golem Balancing

### DIFF
--- a/Main/Include/materia.h
+++ b/Main/Include/materia.h
@@ -164,6 +164,7 @@ class material
   static material* MakeMaterial(int, long = 0);
   virtual truth IsFlesh() const { return false; }
   virtual truth IsLiquid() const { return false; }
+  virtual truth IsGaseous() const { return false; }
   virtual cchar* GetConsumeVerb() const;
   entity* GetMotherEntity() const { return MotherEntity; }
   void SetMotherEntity(entity* What) { MotherEntity = What; }
@@ -191,7 +192,7 @@ class material
   virtual truth TryToRust(long, long = 0) { return false; }
   static const database* GetDataBase(int);
   virtual truth CanSpoil() const { return false; }
-  truth IsSolid() const { return !IsLiquid(); }
+  truth IsSolid() const { return !IsLiquid() && !IsGaseous(); }
   /* A dummy materialpredicate */
   truth True() const { return true; }
   void FinishConsuming(character*);

--- a/Main/Include/materias.h
+++ b/Main/Include/materias.h
@@ -79,6 +79,7 @@ MATERIAL(organic, solid)
 MATERIAL(gas, material)
 {
   virtual int IsBurning() const { return 0; }
+  virtual truth IsGaseous() const { return true; }
 };
 
 MATERIAL(liquid, material)

--- a/Main/Source/human.cpp
+++ b/Main/Source/human.cpp
@@ -5719,8 +5719,6 @@ void golem::CreateCorpse(lsquare* Square)
 {
   material* Material = GetTorso()->GetMainMaterial();
 
-  if(Material->IsSolid())
-    Square->AddItem(Material->CreateNaturalForm(ItemVolume));
   if(Material->IsLiquid())
   {
     for(int d = 0; d < GetExtendedNeighbourSquares(); ++d)
@@ -5730,6 +5728,14 @@ void golem::CreateCorpse(lsquare* Square)
       if(NeighbourSquare)
         NeighbourSquare->SpillFluid(0, static_cast<liquid*>(GetTorso()->GetMainMaterial()->SpawnMore(250 + RAND() % 250)));
     }
+  }
+  else if(Material->IsGaseous())
+  {
+    GetLevel()->GasExplosion(static_cast<gas*>(Material), GetLSquareUnder(), this);
+  }
+  else if(Material->IsSolid())
+  {
+    Square->AddItem(Material->CreateNaturalForm(ItemVolume));
   }
 
   SendToHell();

--- a/Script/char.dat
+++ b/Script/char.dat
@@ -2802,7 +2802,8 @@ golem
   UsesNutrition = false;
   AttachedGod = NONE;
   ClassStates = GAS_IMMUNITY;
-  Frequency = 300;
+  Frequency = 100;
+  DangerModifier = 2000;
   DayRequirementForGeneration = 3;
   CanTalk = false;
   CanRead = true;


### PR DESCRIPTION
Golem spawning rates are still not OK, with powerful golems sometimes 
spawning way too early and often. This commit tries to address the 
issue. Some playtesting I was able to do seems to suggest that golems
are a bit less likely to spawn too early and made of too strong materials,
but IDK if the issue of golems is truly solved.

Also handle theoretical gaseous golems.