### PR TITLE
Use XDG_DATA_HOME instead of HOME when available

### DIFF
--- a/FeLib/Source/save.cpp
+++ b/FeLib/Source/save.cpp
@@ -813,17 +813,21 @@ festring GetUserDataDir()
 {
 #ifdef UNIX
   festring Dir;
-  Dir << getenv("HOME");
 #ifdef MAC_APP
-  Dir << "/Library/Application Support/IVAN/";
+  Dir << getenv("HOME") << "/Library/Application Support/IVAN/";
 #else
-  Dir << "/.ivan/";
-#endif
+  char *xdg_home = getenv("XDG_DATA_HOME"); // check if XDG_DATA_HOME is set
+  if (xdg_home != NULL) { // if it is, use that directory
+          Dir << xdg_home << "/ivan/";
+  } else { // otherwise, default to home directory
+          Dir << getenv("HOME") << "/.ivan/";
+  }
+#endif /* MAC_APP */
 #ifdef DBGMSG
   dbgmsg::SetDebugLogPath(Dir.CStr());
-#endif
+#endif /* DBGMSG */
   return Dir;
-#endif
+#endif /* UNIX */
 
 #if defined(WIN32) || defined(__DJGPP__)
   return "./";


### PR DESCRIPTION
GetUserDataDir is changed for Linux systems to use XDG_DATA_HOME/ivan/ if the variable is set, otherwise it defaults to ~/.ivan/.

Some Linux users like to comply with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). Essentially, this just means that hidden files and folders normally in the ~/ directory be moved to either ~/.config/ or ~/.local/share/. Typically, the user has to set the environment variables for XDG_CONFIG_HOME and/or XDG_DATA_HOME if they want the files/folders moved, otherwise those variables are unset by default.