### PR TITLE
Only use ALSA on Linux

### DIFF
--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -10,7 +10,7 @@ if(WIN32)
 endif()
 
 # Add RtMidi dependencies on Linux
-if(UNIX AND NOT APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   add_definitions(-D__LINUX_ALSA__)
   find_package(ALSA)
   set(RTMIDI_DEPENDENCIES ${ALSA_LIBRARY} pthread)


### PR DESCRIPTION
ALSA is Linux specific and is not available on e.g. *BSD systems, so only use it on Linux