### PR TITLE
Release build for legacy macos (10.9+) on the latest MacOS (11.6.2)

### DIFF
--- a/.github/workflows/build-osx-wizmode.yml
+++ b/.github/workflows/build-osx-wizmode.yml
@@ -1,3 +1,9 @@
+# https://github.com/actions/cache
+# https://github.com/actions/checkout
+# https://github.com/ncipollo/release-action
+# https://docs.github.com/actions/using-workflows
+# https://docs.github.com/actions/learn-github-actions/contexts
+
 name: osx-wizmode
 on: [push]
 
@@ -7,11 +13,16 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # custom libpng build fails a test on macos-latest (11.x)
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
       - name: make-build-dir
         run: mkdir build
+
       - name: Print github workspace
         run: |
           echo "PWD = $PWD"
@@ -19,18 +30,39 @@ jobs:
           echo "github.workspace = ${{ github.workspace }}"
           echo "${{runner.workspace}}"
           echo "HOME = $HOME"
+
       - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $GITHUB_ENV
+
       - name: Show git tag
         run: |
           echo $RELEASE_VERSION
           echo ${{ env.RELEASE_VERSION }}
+
+      - name: Generate cache key
+        run: |
+          key="$(grep -o "'https://[^']*'" ci/osx/requirements.sh | openssl dgst -sha256 -hex)"
+          echo "CACHE_KEY=${key#* }" >> $GITHUB_ENV
+      - name: Reuse cached files
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/Thirdparty/Frameworks
+          key: ${{ runner.os }}-${{ env.CACHE_KEY }}
+
       - name: CI-Build
         shell: bash
         working-directory: ${{github.workspace}}/build
         env:
           CXXFLAGS: -DWIZARD
         run: |
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/ ]]; then
+              export TODO_BREW_UPDATE=ON
+              export MACOSX_DEPLOYMENT_TARGET=10.9
+              echo MACOSX_DEPLOYMENT_TARGET = $MACOSX_DEPLOYMENT_TARGET
+          fi
           export SDL2DIR="$HOME/Thirdparty/Frameworks"
           export BUILD_MAC_APP=ON
           export IVAN_BUILD_DIR="${{github.workspace}}/build"
@@ -39,14 +71,23 @@ jobs:
           ../ci/osx/build.sh
           make install
           ../ci/osx/package.sh
-          ls ./osx
 
       # Attention: you perform the release step when you push a tag, neat huh?
       - name: Release
-        uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
+        #if: startsWith(github.ref, 'refs/tags/') && github.repository == 'attnam/ivan'
+        uses: ncipollo/release-action@v1
         with:
-          files: ${{github.workspace}}/build/osx/*.dmg
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #GITHUB_REPOSITORY: attnam/ivan
+          token: ${{ github.token }}
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          removeArtifacts: false
+          replacesArtifacts: true
+          generateReleaseNotes: false
+          artifacts: ${{github.workspace}}/build/osx/*.dmg
+          artifactContentType: raw
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          draft: false
+          prerelease: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       os: osx
       compiler: gcc
 
-    - env: CXXFLAGS=-DWIZARD IVAN_PLATFORM=win
+    - env: CXXFLAGS=-DWIZARD IVAN_PLATFORM=
       os: linux
       compiler: gcc
 

--- a/ci/osx/libpng.rb
+++ b/ci/osx/libpng.rb
@@ -1,0 +1,90 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2009-present, Homebrew contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Derived from https://github.com/Homebrew/homebrew-core/blob/c3005baf36a2f8677073a8acb1d71bf8de4e0d77/Formula/libpng.rb
+class Libpng < Formula
+  desc "Library for manipulating PNG images"
+  homepage "http://www.libpng.org/pub/png/libpng.html"
+  url "https://downloads.sourceforge.net/project/libpng/libpng16/1.6.37/libpng-1.6.37.tar.xz"
+  mirror "https://sourceforge.mirrorservice.org/l/li/libpng/libpng16/1.6.37/libpng-1.6.37.tar.xz"
+  sha256 "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca"
+  license "libpng-2.0"
+
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/libpng[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+
+  bottle do
+    sha256 cellar: :any,                 arm64_monterey: "40b9dd222c45fb7e2ae3d5c702a4529aedf8c9848a5b6420cb951e72d3ad3919"
+    sha256 cellar: :any,                 arm64_big_sur:  "766a7136ee626b411fb63da0c7e5bc1e848afb6e224622f25ea305b2d1a4a0f1"
+    sha256 cellar: :any,                 monterey:       "7209cfe63b2e8fdbd9615221d78201bfac44405f5206f7b08867bcd0c6046757"
+    sha256 cellar: :any,                 big_sur:        "a8f1c35f9f004c4f7878c30027e35a9fb9551782df963f88deebd3dc29d94d51"
+    sha256 cellar: :any,                 catalina:       "c8e74da602c21f978cd7ee3d489979b4fc6681e71f678a1d99012943ee3a909f"
+    sha256 cellar: :any,                 mojave:         "53bbd14cc27c86c16605e256e7646a1b5656c253abca084958c5d80a2961cb01"
+    sha256 cellar: :any,                 high_sierra:    "bbdd94bdd5954bc50c096391486e67265dce5631efb913dcffe4469806a242b6"
+    sha256 cellar: :any,                 sierra:         "e66797079a9a8134f91bd36b58054c6c32f6a9cd161c1bd19f0192319edb80aa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "aeb238f8b62e3e8923a032caf88152e287a4435ab4afd663fa98b4a57495d116"
+  end
+
+  head do
+    url "https://github.com/glennrp/libpng.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  uses_from_macos "zlib"
+
+  def install
+    args = []
+    args << "MACOSX_DEPLOYMENT_TARGET=X_MACOSX_DEPLOYMENT_TARGET"
+    args << "CFLAGS= -mmacosx-version-min=X_MACOSX_DEPLOYMENT_TARGET -fno-stack-check "
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}", *args
+    system "make"
+    system "make", "test"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <png.h>
+      int main()
+      {
+        png_structp png_ptr;
+        png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+        png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lpng", "-o", "test"
+    system "./test"
+  end
+end

--- a/ci/osx/package.sh
+++ b/ci/osx/package.sh
@@ -73,5 +73,6 @@ install_name_tool -change "${libpng}" @loader_path/../Frameworks/libpng.dylib "$
 #fi
 
 # for a compact dmg file
-hdiutil create -fs HFSX -fsargs '-c c=64,a=16,e=16' -format UDBZ \
+hdiutil create -fs HFSX -fsargs '-c c=64,a=16,e=16' \
+               -format UDZO -imagekey zlib-level=9 \
                -volname "${FILENAME}" -srcfolder "${GAME_DIR}" "${DMG_FILE}"

--- a/ci/osx/pcre.rb
+++ b/ci/osx/pcre.rb
@@ -1,0 +1,102 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2009-present, Homebrew contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Derived from https://github.com/Homebrew/homebrew-core/blob/c3005baf36a2f8677073a8acb1d71bf8de4e0d77/Formula/pcre.rb
+class Pcre < Formula
+  desc "Perl compatible regular expressions library"
+  homepage "https://www.pcre.org/"
+  license "BSD-3-Clause"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.tar.bz2"
+    mirror "https://ftp.exim.org/pub/pcre/pcre-8.45.tar.bz2"
+    mirror "https://www.mirrorservice.org/sites/ftp.exim.org/pub/pcre/pcre-8.45.tar.bz2"
+    sha256 "4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
+
+  livecheck do
+    skip "No version information available"
+    #url "https://ftp.pcre.org/pub/pcre/"
+    #regex(/href=.*?pcre[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  bottle do
+    sha256 cellar: :any,                 arm64_monterey: "11193fd0a113c0bb330b1c2c21ab6f40d225c1893a451bba85e8a1562b914a1c"
+    sha256 cellar: :any,                 arm64_big_sur:  "2d6bfcafce9da9739e32ee433087e69a78cda3f18291350953e6ad260fefc50b"
+    sha256 cellar: :any,                 monterey:       "5e5cc7a5bf8bb6488ec57d4263bf6b0bc89e93252a0a2460f846de29373162d8"
+    sha256 cellar: :any,                 big_sur:        "fb2fefbe1232706a603a6b385fc37253e5aafaf3536cb68b828ad1940b95e601"
+    sha256 cellar: :any,                 catalina:       "180d88dc2230e98162685b86d00436903db4349aac701f9769997d61adb78418"
+    sha256 cellar: :any,                 mojave:         "a42b79956773d18c4ac337868cfc15fadadf5e779d65c12ffd6f8fd379b5514c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "296026b6d5430399e40fb4f8074045a9a27d5374d83f2f6d4659c2647959f36d"
+  end
+
+  head do
+    url "svn://vcs.exim.org/pcre/code/trunk"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  def install
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --enable-utf8
+      --enable-pcre8
+      --enable-pcre16
+      --enable-pcre32
+      --enable-unicode-properties
+      --enable-pcregrep-libz
+      --enable-pcregrep-libbz2
+    ]
+
+    # JIT not currently supported for Apple Silicon or OS older than sierra
+    args << "--enable-jit=no"
+    args << "MACOSX_DEPLOYMENT_TARGET=X_MACOSX_DEPLOYMENT_TARGET"
+    args << "CFLAGS= -mmacosx-version-min=X_MACOSX_DEPLOYMENT_TARGET -fno-stack-check "
+
+    system "./autogen.sh" if build.head?
+    system "./configure", *args
+    system "make"
+    ENV.deparallelize
+    system "make", "test"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/pcregrep", "regular expression", "#{prefix}/README"
+  end
+end

--- a/ci/osx/requirements.sh
+++ b/ci/osx/requirements.sh
@@ -8,6 +8,9 @@ fi
 
 CACHE_DIR="${SDL2DIR}"
 
+# directory of this script
+SCRIPT_DIR=$(dirname -- "$0")
+
 brew_install() {
   for dep in "$@"; do
     if brew list "${dep}" &>/dev/null; then
@@ -21,39 +24,60 @@ brew_install() {
 }
 
 install_sdl2() {
+  local dirs=(
+    'SDL2.framework'
+    'SDL2_mixer.framework'
+  )
   local urls=(
-    'https://libsdl.org/release/SDL2-2.0.9.dmg'
+    'https://libsdl.org/release/SDL2-2.0.20.dmg'
     'https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.dmg'
   )
 
   mkdir -p "${CACHE_DIR}"
-  if [[ "${CACHE_DIR}" = "$(find "${CACHE_DIR}" -maxdepth 0 -type d -empty)" ]]
-  then
-    local tmpdir=$(mktemp -d)
+
+  local i
+  for i in "${!urls[@]}"; do
+    local dir="${dirs[$i]}" url="${urls[$i]}"
+
+    if [[ -d "${CACHE_DIR}/${dir}" ]]; then
+      continue
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    trap 'hdiutil detach sdl >/dev/null 2>&1 || true; rm -Rf "${tmpdir}"' RETURN
     pushd "${tmpdir}"
 
-    local url
-    for url in "${urls[@]}"; do
-      curl -L --fail --retry 5 -o sdl.dmg "${url}"
-      hdiutil attach -readonly -mount required -mountpoint sdl sdl.dmg
-      cp -R sdl/* "${CACHE_DIR}"
-      hdiutil detach sdl
-      rm sdl.dmg
-    done
+    curl -L --fail --retry 5 -o sdl.dmg "${url}"
+    hdiutil attach -readonly -mount required -mountpoint sdl sdl.dmg
+    cp -R sdl/"${dir}" "${CACHE_DIR}"
+    hdiutil detach sdl
+    rm sdl.dmg
 
     popd
     rm -Rf "${tmpdir}"
-  fi
+  done
 
   echo "Cached Frameworks:"
   ls -hl "${CACHE_DIR}"
 }
 
 if [[ -n "${IVAN_PLATFORM}" || "${BUILD_MAC_APP}" = ON ]]; then
-  if [[ -n "${TRAVIS_TAG}" ]]; then
-    brew update  # for deployment
+  ## pcre and libpng are quiet stable, the CI servers can do better here
+  #if [[ -n "${TRAVIS_TAG}" || "${TODO_BREW_UPDATE}" = ON ]]; then
+  #  brew update  # for deployment
+  #fi
+  brew_install pkg-config cmake
+  if [[ -n "${MACOSX_DEPLOYMENT_TARGET}" ]]; then
+    # dyld: lazy symbol binding failed: Symbol not found: ____chkstk_darwin
+    for formula in "${SCRIPT_DIR}"/{pcre,libpng}.rb; do
+      # brew will sanitize environment variables, therefore...
+      sed -i.orig "s/X_MACOSX_DEPLOYMENT_TARGET/${MACOSX_DEPLOYMENT_TARGET}/g" "${formula}"
+      brew reinstall --force --build-from-source --formula "${formula}"
+      mv "${formula}"{.orig,}
+    done
+  else
+    brew_install pcre libpng
   fi
-  brew_install pkg-config cmake pcre libpng
   install_sdl2
 else
   brew_install pkg-config cmake pcre libpng sdl2 sdl2_mixer


### PR DESCRIPTION
One libpng test fails randomly, should change os to macos-10.15?

Test files:

- built on macos-10.15: https://github.com/jakwings/ivan/releases/download/v059-patch1/IVAN-v059-patch1-osx.dmg
- built on macos-latest: https://github.com/jakwings/ivan/releases/download/v059-patch2/IVAN-v059-patch2-osx.dmg
