### PR TITLE
Fix crash on Linux systems about missing user data folder

### DIFF
--- a/FeLib/Source/save.cpp
+++ b/FeLib/Source/save.cpp
@@ -820,7 +820,9 @@ festring GetUserDataDir()
   if (xdg_home != NULL) { // if it is, use that directory
           Dir << xdg_home << "/ivan/";
   } else { // otherwise, default to home directory
+          struct stat folderInfo = {0};
           Dir << getenv("HOME") << "/.ivan/";
+          if(stat(Dir.CStr(), &folderInfo) == -1) mkdir(Dir.CStr(), 0755); //Check if user data folder doesn't exists, create it if true
   }
 #endif /* MAC_APP */
 #ifdef DBGMSG


### PR DESCRIPTION
Possibly fixes issue #645 .
The issue was fixed by creating a folder named `.ivan` in `${HOME}`, This pull request adds a check if this folder already exists. If it doesn't it creates it.