### PR TITLE
cmdcraft: fix tailoring crash

### DIFF
--- a/Main/Source/cmdcraft.cpp
+++ b/Main/Source/cmdcraft.cpp
@@ -2658,6 +2658,7 @@ struct srpForgeItem : public recipe{
       CISW.bMainMaterRemainsBecomeLump=true;
       CISW.bMixRemainingLump = false;
       CISW.iReqMatCfgMain=SPIDER_SILK;
+      CISW.bIsMainIngredient = false;
       if(!choseIngredients<lump>(cfestring("as sewing material"),lVolSewing,rpd,iSCfg,CISW)){ //TODO instead of <lump> should be <sewingthread> with new graphics
         ADD_MESSAGE("You don't have enough sewing thread...");
         rpd.SetAlreadyExplained();


### PR DESCRIPTION
Mark sewing thread as secondary material.

This fixes an abort [here](https://github.com/Attnam/ivan/blob/master/Main/Source/cmdcraft.cpp#L1185) that I was running into whenever trying to tailor anything.  I'm not sure if this is the correct way to fix it, but it seems to work.