### PR TITLE
char: fix null deref when trying to remove trap

### DIFF
--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -12099,6 +12099,8 @@ struct trapidcomparer
 void character::RemoveTrap(ulong ID)
 {
   trapdata*& T = ListFind(TrapData, trapidcomparer(ID));
+  if (T == nullptr)
+    return;
   trapdata* ToDel = T;
   T = T->Next;
   delete ToDel;


### PR DESCRIPTION
Cutting down a web can try to remove the trap from a character on the square that isn't actually trapped.  Do nothing in this case.