### PR TITLE
Easier input on some more modern devices

### DIFF
--- a/FeLib/Include/felibdef.h
+++ b/FeLib/Include/felibdef.h
@@ -205,6 +205,12 @@ inline int GetMinColor24(col24 Color)
 #define KEY_SPACE ' '
 #define KEY_NUMPAD_5 2
 
+#define KEY_CONTROLLER_DIRECTION 0x200 /* 1 to 9 is added, similar to a numpad */
+#define KEY_CONTROLLER_A         0x205
+#define KEY_CONTROLLER_B         0x210
+#define KEY_CONTROLLER_X         0x211
+#define KEY_CONTROLLER_Y         0x212
+
 #define NO_FLAME 0xFFFF
 
 #define SELECTABLE 1

--- a/FeLib/Include/felibdef.h
+++ b/FeLib/Include/felibdef.h
@@ -218,6 +218,7 @@ inline int GetMinColor24(col24 Color)
 #define BLIT_AFTERWARDS 4
 #define DRAW_BACKGROUND_AFTERWARDS 8
 #define FADE 16
+#define DONT_SHOW_KEYS 32
 
 /* felist errors */
 

--- a/FeLib/Include/whandler.h
+++ b/FeLib/Include/whandler.h
@@ -88,6 +88,21 @@ class globalwindowhandler
   const static int iRestWaitKey;
   static void AddKeyToBuffer(int KeyPressed);
 
+  static bool ControllerEnabled() {
+    #if SDL_MAJOR_VERSION == 2
+    return controllers.size() > 0;
+    #else
+    return false;
+    #endif
+    }
+  static v2 GetControllerDirection() {
+    #if SDL_MAJOR_VERSION == 2
+    return controller_direction;
+    #else
+    return v2(0, 0);
+    #endif
+    }
+
  private:
 #ifdef USE_SDL
   static int ChkCtrlKey(SDL_Event* Event);
@@ -104,6 +119,11 @@ class globalwindowhandler
   static truth ControlLoopsEnabled;
   static truth playInBackground;
   static festring ScrshotDirectoryName;
+
+#if SDL_MAJOR_VERSION == 2
+  static std::vector<SDL_GameController*> controllers;
+  static v2 controller_direction;
+#endif
 };
 
 #endif

--- a/FeLib/Include/whandler.h
+++ b/FeLib/Include/whandler.h
@@ -86,13 +86,13 @@ class globalwindowhandler
 #endif
 
   const static int iRestWaitKey;
+  static void AddKeyToBuffer(int KeyPressed);
 
  private:
 #ifdef USE_SDL
   static int ChkCtrlKey(SDL_Event* Event);
   static void ProcessMessage(SDL_Event*);
   static void ProcessKeyDownMessage(SDL_Event* Event);
-  static void AddKeyToBuffer(int KeyPressed);
   static std::vector<int> KeyBuffer;
   static truth (*QuitMessageHandler)();
   static bool (*FunctionKeyHandler)(SDL_Keycode);

--- a/FeLib/Source/feio.cpp
+++ b/FeLib/Source/feio.cpp
@@ -326,6 +326,7 @@ int iosystem::Menu(std::vector<bitmap*> vBackGround, v2 Pos,
       break;
 
      case 0x00D:
+     case KEY_CONTROLLER_A:
       bReady = true;
       break;
 

--- a/FeLib/Source/felist.cpp
+++ b/FeLib/Source/felist.cpp
@@ -306,7 +306,7 @@ uint felist::Draw()
 
   ApplyFilter();
 
-  if(Flags & SELECTABLE){
+  if(Flags & SELECTABLE && !(Flags & DONT_SHOW_KEYS)){
     if(PageLength > 26)PageLength=26; //constraint limit from aA to zZ as there is no coded support beyond these keys anyways...
   }else{
     for(int i=0;i<Entry.size();i++)
@@ -634,7 +634,7 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
     if(bJustRefreshOnce)
       continue;
 
-    if((Flags & SELECTABLE) && Pressed > 64 // 65='A' 90='Z'
+    if((Flags & SELECTABLE) && !(Flags & DONT_SHOW_KEYS) && Pressed > 64 // 65='A' 90='Z'
        && Pressed < 91 && Pressed - 65 < PageLength
        && Pressed - 65 + PageBegin < Selectables)
     {DBGLN;
@@ -643,7 +643,7 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
       break;
     }
 
-    if((Flags & SELECTABLE) && Pressed > 96 // 97='a' 122='z'
+    if((Flags & SELECTABLE) && !(Flags & DONT_SHOW_KEYS) && Pressed > 96 // 97='a' 122='z'
        && Pressed < 123 && Pressed - 97 < PageLength
        && Pressed - 97 + PageBegin < Selectables)
     {DBGLN;
@@ -861,7 +861,7 @@ truth felist::DrawPage(bitmap* Buffer, v2* pv2FinalPageSize, std::vector<EntryRe
     uint Marginal = Entry[c]->Marginal;
 
     bool bIsSelectable = (Flags & SELECTABLE) && Entry[c]->Selectable;
-    if(bIsSelectable){
+    if(bIsSelectable && !(Flags & DONT_SHOW_KEYS)){
       Str << char('A' + (i - PageBegin)) << ": ";
       Marginal += 3;
     }

--- a/FeLib/Source/felist.cpp
+++ b/FeLib/Source/felist.cpp
@@ -715,6 +715,21 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
       break;
     }
 
+    if((Flags & SELECTABLE) && (Pressed >= KEY_CONTROLLER_DIRECTION + 1 && Pressed <= KEY_CONTROLLER_DIRECTION + 9))
+    {
+      auto p = PageBegin;
+      Selected = Selected + Pressed - KEY_CONTROLLER_A;
+      if(Selected > Selectables - 1) Selected = Selectables - 1;
+      if(Selected < 0) Selected = 0;
+      while(Selected < PageBegin && PageLength) PageBegin -= PageLength;
+      while(Selected >= PageBegin + PageLength && PageLength) PageBegin += PageLength;
+
+      if(p != PageBegin) BackGround.FastBlit(Buffer);
+      else JustRedrawEverythingOnce = true;
+
+      continue;
+    }
+
     if(bApplyNewFilter){DBGLN;
       break;
     }

--- a/FeLib/Source/felist.cpp
+++ b/FeLib/Source/felist.cpp
@@ -735,6 +735,8 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
     if(!bNav && Pressed == KEY_PAGE_UP)bNav=true;
     if(!bNav && Pressed == KEY_HOME)bNav=true;
     if(!bNav && Pressed == KEY_END)bNav=true; //TODO ? END key usage is getting complicated, disabled for now:
+    if(!bNav && Pressed == KEY_DOWN)bNav=true;
+    if(!bNav && Pressed == KEY_UP)bNav=true;
 
     if(Pressed == KEY_SPACE) //to work stictly as on the help info
       if(bInvM ? PageBegin==0 : LastEntryVisible){DBGLN;
@@ -749,7 +751,7 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
       int iDir = 1;
       if(bInvM)
         iDir *= -1;
-      if(Pressed == KEY_PAGE_UP) //TODO confirm that this inverts the INVERSE_MODE behavior
+      if(Pressed == KEY_PAGE_UP || Pressed == KEY_UP) //TODO confirm that this inverts the INVERSE_MODE behavior
         iDir *= -1;
 
       int iPB = PageBegin + iDir*PageLength;DBG1(iPB);

--- a/FeLib/Source/felist.cpp
+++ b/FeLib/Source/felist.cpp
@@ -624,7 +624,7 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
     }
     DBGLN;
 
-    if(Pressed == KEY_ESC) // this here grants will be preferred over everything else below
+    if(Pressed == KEY_ESC || Pressed == KEY_CONTROLLER_B) // this here grants will be preferred over everything else below
     {
       Return = ESCAPED;
       break;
@@ -707,7 +707,7 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
       continue;
     }
 
-    if((Flags & SELECTABLE) && (Pressed == KEY_ENTER || bLeftMouseButtonClick))
+    if((Flags & SELECTABLE) && (Pressed == KEY_ENTER || bLeftMouseButtonClick || Pressed == KEY_CONTROLLER_A))
     {
       Return = Selected;
       if(!bLeftMouseButtonClick)
@@ -737,6 +737,9 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
     if(!bNav && Pressed == KEY_END)bNav=true; //TODO ? END key usage is getting complicated, disabled for now:
     if(!bNav && Pressed == KEY_DOWN)bNav=true;
     if(!bNav && Pressed == KEY_UP)bNav=true;
+    if(!bNav && Pressed == KEY_CONTROLLER_X)bNav=true;
+    if(!bNav && Pressed == KEY_CONTROLLER_Y)bNav=true;
+
 
     if(Pressed == KEY_SPACE) //to work stictly as on the help info
       if(bInvM ? PageBegin==0 : LastEntryVisible){DBGLN;
@@ -751,7 +754,7 @@ uint felist::DrawFiltered(bool& bJustExitTheList)
       int iDir = 1;
       if(bInvM)
         iDir *= -1;
-      if(Pressed == KEY_PAGE_UP || Pressed == KEY_UP) //TODO confirm that this inverts the INVERSE_MODE behavior
+      if(Pressed == KEY_PAGE_UP || Pressed == KEY_UP || Pressed == KEY_CONTROLLER_X) //TODO confirm that this inverts the INVERSE_MODE behavior
         iDir *= -1;
 
       int iPB = PageBegin + iDir*PageLength;DBG1(iPB);

--- a/FeLib/Source/graphics.cpp
+++ b/FeLib/Source/graphics.cpp
@@ -117,6 +117,7 @@ void graphics::Init()
       ABORT("Can't initialize SDL.");
 #if SDL_MAJOR_VERSION == 2
   SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+  SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER);
 #endif
 #endif
 

--- a/FeLib/Source/specialkeys.cpp
+++ b/FeLib/Source/specialkeys.cpp
@@ -264,6 +264,12 @@ bool specialkeys::ControlKeyHandler(SDL_Keycode key)
   case SDLK_DELETE:
     Request=ClearStringInput;
     return true;
+  case SDLK_LEFT:
+    globalwindowhandler::AddKeyToBuffer(KEY_END + 0xE000);
+    break;
+  case SDLK_RIGHT:
+    globalwindowhandler::AddKeyToBuffer(KEY_PAGE_DOWN + 0xE000);
+    break;
   default:
     ckhmap::iterator Iterator = CkhMap.find(key);
     if(Iterator != CkhMap.end()){

--- a/FeLib/Source/whandler.cpp
+++ b/FeLib/Source/whandler.cpp
@@ -630,6 +630,15 @@ void globalwindowhandler::ProcessKeyDownMessage(SDL_Event* Event)
     return;
   }else
   if(Event->key.keysym.mod & KMOD_SHIFT){
+    switch(Event->key.keysym.sym)
+    {
+    case SDLK_LEFT:
+      AddKeyToBuffer(KEY_HOME + 0xE000);
+      break;
+    case SDLK_RIGHT:
+      AddKeyToBuffer(KEY_PAGE_UP + 0xE000);
+      break;
+    }
     return;
   }
 

--- a/FeLib/Source/whandler.cpp
+++ b/FeLib/Source/whandler.cpp
@@ -48,6 +48,9 @@ truth globalwindowhandler::playInBackground=false;
 festring globalwindowhandler::ScrshotDirectoryName = "";
 truth bLastSDLkeyEventIsKeyUp=false;
 
+std::vector<SDL_GameController*> globalwindowhandler::controllers;
+v2 globalwindowhandler::controller_direction;
+
 void globalwindowhandler::InstallControlLoop(truth (*What)())
 {
   if(Controls == MAX_CONTROLS)
@@ -804,6 +807,49 @@ void globalwindowhandler::ProcessMessage(SDL_Event* Event)
    case SDL_TEXTINPUT: DBG2(Event->key.keysym.sym,Event->text.text[0]);
      AddKeyToBuffer(Event->text.text[0]);
      break;
+
+   case SDL_CONTROLLERDEVICEADDED:
+     controllers.push_back(SDL_GameControllerOpen(Event->cdevice.which));
+     break;
+
+   case SDL_CONTROLLERDEVICEREMOVED:
+     for(auto& c: controllers) if(SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(c)) == Event->cdevice.which){
+       SDL_GameControllerClose(c);
+       c = nullptr;
+       std::swap(c, controllers.back());
+     }
+     if(controllers.size() && controllers.back() == nullptr)
+       controllers.pop_back();
+     break;
+
+  case SDL_CONTROLLERAXISMOTION:
+     controller_direction = v2(0, 0);
+     for(auto c: controllers) {
+       auto x = SDL_GameControllerGetAxis(c, SDL_CONTROLLER_AXIS_LEFTX);
+       if(x < -10000) controller_direction.X = -1;
+       if(x >  10000) controller_direction.X = +1;
+       x = SDL_GameControllerGetAxis(c, SDL_CONTROLLER_AXIS_RIGHTX);
+       if(x < -10000) controller_direction.X = -1;
+       if(x >  10000) controller_direction.X = +1;
+       auto y = SDL_GameControllerGetAxis(c, SDL_CONTROLLER_AXIS_LEFTY);
+       if(y < -10000) controller_direction.Y = -1;
+       if(y >  10000) controller_direction.Y = +1;
+       y = SDL_GameControllerGetAxis(c, SDL_CONTROLLER_AXIS_RIGHTY);
+       if(y < -10000) controller_direction.Y = -1;
+       if(y >  10000) controller_direction.Y = +1;
+       }
+     break;
+
+  case SDL_CONTROLLERBUTTONDOWN:
+    if(Event->cbutton.button == SDL_CONTROLLER_BUTTON_DPAD_UP) AddKeyToBuffer(0xE000 + KEY_UP);
+    if(Event->cbutton.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN) AddKeyToBuffer(0xE000 + KEY_DOWN);
+    if(Event->cbutton.button == SDL_CONTROLLER_BUTTON_DPAD_LEFT) AddKeyToBuffer(0xE000 + KEY_LEFT);
+    if(Event->cbutton.button == SDL_CONTROLLER_BUTTON_DPAD_RIGHT) AddKeyToBuffer(0xE000 + KEY_RIGHT);
+    if(Event->cbutton.button == SDL_CONTROLLER_BUTTON_A) AddKeyToBuffer(0xE000 + KEY_CONTROLLER_A + 3 * controller_direction.Y + controller_direction.X);
+    if(Event->cbutton.button == SDL_CONTROLLER_BUTTON_B) AddKeyToBuffer(0xE000 + KEY_CONTROLLER_B);
+    if(Event->cbutton.button == SDL_CONTROLLER_BUTTON_X) AddKeyToBuffer(0xE000 + KEY_CONTROLLER_X);
+    if(Event->cbutton.button == SDL_CONTROLLER_BUTTON_Y) AddKeyToBuffer(0xE000 + KEY_CONTROLLER_Y);
+    break;
 #endif
 
    case SDL_KEYUP: DBGLN;

--- a/Main/Include/char.h
+++ b/Main/Include/char.h
@@ -1193,6 +1193,7 @@ class character : public entity, public id
   festring GetHitPointDescription() const;
   truth WillGetTurnSoon() const;
   virtual void SetFeedingSumo(truth What) { return; }
+  void PerformPlayerCommand(int Key, bool& HasActed, bool& ValidKeyPressed);
  protected:
   static truth DamageTypeDestroysBodyPart(int);
   virtual void LoadSquaresUnder();

--- a/Main/Include/command.h
+++ b/Main/Include/command.h
@@ -50,6 +50,7 @@ class commandsystem
   static void LoadSwapWeapons(inputfile& SaveFile);
   static void ClearSwapWeapons();
   static std::vector<v2> GetRouteGoOnCopy();
+  static truth ShowKeyLayout(character*);
  private:
   static truth Apply(character*);
   static truth ApplyWork(character* Char,item* itOverride=NULL);
@@ -79,7 +80,6 @@ class commandsystem
   static truth Read(character*);
   static truth Save(character*);
   static truth ShowInventory(character*);
-  static truth ShowKeyLayout(character*);
   static truth ShowWeaponSkills(character*);
   static truth Talk(character*);
   static truth Throw(character*);

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -3699,6 +3699,12 @@ void character::PerformPlayerCommand(int Key, bool& HasActed, bool& ValidKeyPres
 
     ValidKeyPressed = true;
     }
+
+  if(Key == KEY_CONTROLLER_Y) {
+    game::RegionListItemEnable(false);
+    game::RegionSilhouetteEnable(false);
+    HasActed = commandsystem::ShowKeyLayout(this);
+    }
 }
 
 void character::GetPlayerCommand()

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -3722,21 +3722,26 @@ void character::GetPlayerCommand()
 
     if(!HasActed){
 
+      auto MoveByVector = [&] (v2 Dir) {
+        bool bWaitNeutralMove=false;
+        HasActed = TryMove(ApplyStateModification(Dir), true, game::PlayerIsRunning(), &bWaitNeutralMove);
+        if(HasActed){
+          game::CheckAddAutoMapNote();
+          game::CheckAutoPickup();
+        }
+        if(!HasActed && bWaitNeutralMove){
+          //cant access.. HasActed = commandsystem::NOP(this);
+          Key = '.'; //TODO request NOP()'s key instead of this '.' hardcoded here. how?
+        }
+        ValidKeyPressed = true;
+        };
+
       for(c = 0; c < DIRECTION_COMMAND_KEYS; ++c)
         if(Key == game::GetMoveCommandKey(c))
-        {
-          bool bWaitNeutralMove=false;
-          HasActed = TryMove(ApplyStateModification(game::GetMoveVector(c)), true, game::PlayerIsRunning(), &bWaitNeutralMove);
-          if(HasActed){
-            game::CheckAddAutoMapNote();
-            game::CheckAutoPickup();
-          }
-          if(!HasActed && bWaitNeutralMove){
-            //cant access.. HasActed = commandsystem::NOP(this);
-            Key = '.'; //TODO request NOP()'s key instead of this '.' hardcoded here. how?
-          }
-          ValidKeyPressed = true;
-        }
+          MoveByVector(game::GetMoveVector(c));
+
+      if(Key >= KEY_CONTROLLER_DIRECTION + 1 && Key <= KEY_CONTROLLER_DIRECTION + 9)
+        MoveByVector(game::GetDirectionVectorForKey(Key));
 
       for(c = 1; commandsystem::GetCommand(c); ++c)
         if(Key == commandsystem::GetCommand(c)->GetKey())

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -3651,6 +3651,52 @@ truth character::AutoPlayAICommand(int& rKey)
   return true;
 }
 
+void character::PerformPlayerCommand(int Key, bool& HasActed, bool& ValidKeyPressed)
+{
+  auto MoveByVector = [&] (v2 Dir) {
+    bool bWaitNeutralMove=false;
+    HasActed = TryMove(ApplyStateModification(Dir), true, game::PlayerIsRunning(), &bWaitNeutralMove);
+    if(HasActed){
+      game::CheckAddAutoMapNote();
+      game::CheckAutoPickup();
+    }
+    if(!HasActed && bWaitNeutralMove){
+      //cant access.. HasActed = commandsystem::NOP(this);
+      Key = '.'; //TODO request NOP()'s key instead of this '.' hardcoded here. how?
+    }
+    ValidKeyPressed = true;
+    };
+
+  int c;
+  for(c = 0; c < DIRECTION_COMMAND_KEYS; ++c)
+    if(Key == game::GetMoveCommandKey(c))
+      MoveByVector(game::GetMoveVector(c));
+
+  if(Key >= KEY_CONTROLLER_DIRECTION + 1 && Key <= KEY_CONTROLLER_DIRECTION + 9)
+    MoveByVector(game::GetDirectionVectorForKey(Key));
+
+  if(ValidKeyPressed) return;
+
+  for(c = 1; commandsystem::GetCommand(c); ++c)
+    if(Key == commandsystem::GetCommand(c)->GetKey())
+    {
+      if(game::IsInWilderness() && !commandsystem::GetCommand(c)->IsUsableInWilderness())
+        ADD_MESSAGE("This function cannot be used while in wilderness.");
+      else
+        if(!game::WizardModeIsActive() && commandsystem::GetCommand(c)->IsWizardModeFunction())
+          ADD_MESSAGE("Activate wizardmode to use this function.");
+        else{
+          game::RegionListItemEnable(commandsystem::IsForRegionListItem(c));
+          game::RegionSilhouetteEnable(commandsystem::IsForRegionSilhouette(c));
+          HasActed = commandsystem::GetCommand(c)->GetLinkedFunction()(this);
+          game::RegionListItemEnable(false);
+          game::RegionSilhouetteEnable(false);
+        }
+
+    ValidKeyPressed = true;
+    }
+}
+
 void character::GetPlayerCommand()
 {
   truth HasActed = false;
@@ -3692,7 +3738,6 @@ void character::GetPlayerCommand()
       msgsystem::ThyMessagesAreNowOld();
 
     truth ValidKeyPressed = false;
-    int c;
 
 #ifdef WIZARD
     if(IsPlayerAutoPlay()){
@@ -3720,50 +3765,8 @@ void character::GetPlayerCommand()
     }
 #endif
 
-    if(!HasActed){
-
-      auto MoveByVector = [&] (v2 Dir) {
-        bool bWaitNeutralMove=false;
-        HasActed = TryMove(ApplyStateModification(Dir), true, game::PlayerIsRunning(), &bWaitNeutralMove);
-        if(HasActed){
-          game::CheckAddAutoMapNote();
-          game::CheckAutoPickup();
-        }
-        if(!HasActed && bWaitNeutralMove){
-          //cant access.. HasActed = commandsystem::NOP(this);
-          Key = '.'; //TODO request NOP()'s key instead of this '.' hardcoded here. how?
-        }
-        ValidKeyPressed = true;
-        };
-
-      for(c = 0; c < DIRECTION_COMMAND_KEYS; ++c)
-        if(Key == game::GetMoveCommandKey(c))
-          MoveByVector(game::GetMoveVector(c));
-
-      if(Key >= KEY_CONTROLLER_DIRECTION + 1 && Key <= KEY_CONTROLLER_DIRECTION + 9)
-        MoveByVector(game::GetDirectionVectorForKey(Key));
-
-      for(c = 1; commandsystem::GetCommand(c); ++c)
-        if(Key == commandsystem::GetCommand(c)->GetKey())
-        {
-          if(game::IsInWilderness() && !commandsystem::GetCommand(c)->IsUsableInWilderness())
-            ADD_MESSAGE("This function cannot be used while in wilderness.");
-          else
-            if(!game::WizardModeIsActive() && commandsystem::GetCommand(c)->IsWizardModeFunction())
-              ADD_MESSAGE("Activate wizardmode to use this function.");
-            else{
-              game::RegionListItemEnable(commandsystem::IsForRegionListItem(c));
-              game::RegionSilhouetteEnable(commandsystem::IsForRegionSilhouette(c));
-              HasActed = commandsystem::GetCommand(c)->GetLinkedFunction()(this);
-              game::RegionListItemEnable(false);
-              game::RegionSilhouetteEnable(false);
-            }
-
-          ValidKeyPressed = true;
-          break;
-        }
-
-    }
+    if(!HasActed)
+      PerformPlayerCommand(Key, HasActed, ValidKeyPressed);
 
     if(!ValidKeyPressed)
       ADD_MESSAGE("Unknown key. Press '?' for a list of commands.");

--- a/Main/Source/char.cpp
+++ b/Main/Source/char.cpp
@@ -3654,6 +3654,10 @@ truth character::AutoPlayAICommand(int& rKey)
 void character::PerformPlayerCommand(int Key, bool& HasActed, bool& ValidKeyPressed)
 {
   auto MoveByVector = [&] (v2 Dir) {
+    if(Dir == v2(0, 0)){
+      Key = '.';
+      return;
+    }
     bool bWaitNeutralMove=false;
     HasActed = TryMove(ApplyStateModification(Dir), true, game::PlayerIsRunning(), &bWaitNeutralMove);
     if(HasActed){

--- a/Main/Source/cmdcraft.cpp
+++ b/Main/Source/cmdcraft.cpp
@@ -3199,10 +3199,12 @@ truth craftcore::Craft(character* Char) //TODO currently this is an over simplif
     }
     if(sel==0 && craftcore::HasSuspended()){
       int key = game::KeyQuestion(CONST_S("There are suspended crafting actions: (r)esume/ENTER or (c)ancel?"),
-        KEY_ESC, 3, 'r', 'c', KEY_ENTER);
-      if(key==KEY_ESC)return false;
+        KEY_ESC, 6, 'r', 'c', KEY_ENTER, KEY_CONTROLLER_A, KEY_CONTROLLER_Y, KEY_CONTROLLER_B);
+      if(key==KEY_ESC || key == KEY_CONTROLLER_B)return false;
 
       if(key==KEY_ENTER)key='r';
+      if(key == KEY_CONTROLLER_A) key = 'r';
+      if(key == KEY_CONTROLLER_Y) key = 'c';
 
       felist LSusp("Suspended crafting actions:",WHITE);
       game::SetStandardListAttributes(LSusp);

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -966,8 +966,8 @@ truth commandsystem::ShowKeyLayout(character*)
                                       << "commands are only accessible in wizard mode. Note that the game "
                                       << "distinguishes between lowercase and uppercase letters, so if you are "
                                       << "experiencing troubles, first check whether you don't have active CapsLock.");
-     List.AddEntry(CONST_S("4 6        or use arrow keys and"), LIGHT_GRAY);
-     List.AddEntry(CONST_S("123        Home, End, PgUp, PgDn"), LIGHT_GRAY);
+     List.AddEntry(CONST_S("4 6        or use arrow keys and Home, End, PgUp, PgDn"), LIGHT_GRAY);
+     List.AddEntry(CONST_S("123        you can also use Left/Right + Shift/Ctrl for diagonals"), LIGHT_GRAY);
      break;
    }
    case DIR_ALT: // Alternative

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -1024,9 +1024,9 @@ truth commandsystem::ShowKeyLayout(character* Who)
   }
 
   game::SetStandardListAttributes(List);
-  List.AddFlags(SELECTABLE | DONT_SHOW_KEYS);
+  if(Who) List.AddFlags(SELECTABLE | DONT_SHOW_KEYS);
   int res = List.Draw();
-  if(res >= 0 && res < keys.size()) {
+  if(Who && res >= 0 && res < keys.size()) {
     bool HasActed = false, ValidKeyPressed = false;
     Who->PerformPlayerCommand(keys[res], HasActed, ValidKeyPressed);
     return HasActed;

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -946,7 +946,7 @@ truth commandsystem::Dip(character* Char)
   return false;
 }
 
-truth commandsystem::ShowKeyLayout(character*)
+truth commandsystem::ShowKeyLayout(character* Who)
 {
   felist List(CONST_S("Keyboard Layout"));
   List.AddDescription(CONST_S(""));
@@ -961,38 +961,40 @@ truth commandsystem::ShowKeyLayout(character*)
   {
    case DIR_NORM: // Normal
    {
-     List.AddEntry(CONST_S("789       movement (normal)"), LIGHT_GRAY);
+     List.AddEntry(CONST_S("789       movement (normal)"), LIGHT_GRAY, 0, NO_IMAGE, false);
      List.SetLastEntryHelp(festring() << "IVAN uses most of the keyboard for command key bindings, though some "
                                       << "commands are only accessible in wizard mode. Note that the game "
                                       << "distinguishes between lowercase and uppercase letters, so if you are "
                                       << "experiencing troubles, first check whether you don't have active CapsLock.");
-     List.AddEntry(CONST_S("4 6        or use arrow keys and Home, End, PgUp, PgDn"), LIGHT_GRAY);
-     List.AddEntry(CONST_S("123        you can also use Left/Right + Shift/Ctrl for diagonals"), LIGHT_GRAY);
+     List.AddEntry(CONST_S("4 6        or use arrow keys and Home, End, PgUp, PgDn"), LIGHT_GRAY, 0, NO_IMAGE, false);
+     List.AddEntry(CONST_S("123        you can also use Left/Right + Shift/Ctrl for diagonals"), LIGHT_GRAY, 0, NO_IMAGE, false);
      break;
    }
    case DIR_ALT: // Alternative
    {
-     List.AddEntry(CONST_S("789       movement (alternative)"), LIGHT_GRAY);
+     List.AddEntry(CONST_S("789       movement (alternative)"), LIGHT_GRAY, 0, NO_IMAGE, false);
      List.SetLastEntryHelp(festring() << "IVAN uses most of the keyboard for command key bindings, though some "
                                       << "commands are only accessible in wizard mode. Note that the game "
                                       << "distinguishes between lowercase and uppercase letters, so if you are "
                                       << "experiencing troubles, first check whether you don't have active CapsLock.");
-     List.AddEntry(CONST_S("u o"), LIGHT_GRAY);
-     List.AddEntry(CONST_S("jkl"), LIGHT_GRAY);
+     List.AddEntry(CONST_S("u o"), LIGHT_GRAY, 0, NO_IMAGE, false);
+     List.AddEntry(CONST_S("jkl"), LIGHT_GRAY, 0, NO_IMAGE, false);
      break;
    }
    case DIR_HACK: // Nethack
    {
-     List.AddEntry(CONST_S("yku       movement (NetHack)"), LIGHT_GRAY);
+     List.AddEntry(CONST_S("yku       movement (NetHack)"), LIGHT_GRAY, 0, NO_IMAGE, false);
      List.SetLastEntryHelp(festring() << "IVAN uses most of the keyboard for command key bindings, though some "
                                       << "commands are only accessible in wizard mode. Note that the game "
                                       << "distinguishes between lowercase and uppercase letters, so if you are "
                                       << "experiencing troubles, first check whether you don't have active CapsLock.");
-     List.AddEntry(CONST_S("h l"), LIGHT_GRAY);
-     List.AddEntry(CONST_S("bjn"), LIGHT_GRAY);
+     List.AddEntry(CONST_S("h l"), LIGHT_GRAY, 0, NO_IMAGE, false);
+     List.AddEntry(CONST_S("bjn"), LIGHT_GRAY, 0, NO_IMAGE, false);
      break;
    }
   }
+
+  std::vector<int> keys;
 
   for(int c = 1; GetCommand(c); ++c)
     if(!GetCommand(c)->IsWizardModeFunction())
@@ -1000,14 +1002,15 @@ truth commandsystem::ShowKeyLayout(character*)
       Buffer.Empty();
       Buffer << game::ToCharIfPossible(GetCommand(c)->GetKey());
       Buffer.Resize(10);
-      List.AddEntry(Buffer + GetCommand(c)->GetDescription(), LIGHT_GRAY);
+      List.AddEntry(Buffer + GetCommand(c)->GetDescription(), LIGHT_GRAY, 0, NO_IMAGE, true);
+      keys.push_back(GetCommand(c)->GetKey());
     }
 
   if(game::WizardModeIsActive())
   {
-    List.AddEntry(CONST_S(""), WHITE);
-    List.AddEntry(CONST_S("Wizard mode functions:"), WHITE);
-    List.AddEntry(CONST_S(""), WHITE);
+    List.AddEntry(CONST_S(""), WHITE, 0, NO_IMAGE, false);
+    List.AddEntry(CONST_S("Wizard mode functions:"), WHITE, 0, NO_IMAGE, false);
+    List.AddEntry(CONST_S(""), WHITE, 0, NO_IMAGE, false);
 
     for(int c = 1; GetCommand(c); ++c)
       if(GetCommand(c)->IsWizardModeFunction())
@@ -1015,12 +1018,20 @@ truth commandsystem::ShowKeyLayout(character*)
         Buffer.Empty();
         Buffer << game::ToCharIfPossible(GetCommand(c)->GetKey());
         Buffer.Resize(10);
-        List.AddEntry(Buffer + GetCommand(c)->GetDescription(), LIGHT_GRAY);
+        List.AddEntry(Buffer + GetCommand(c)->GetDescription(), LIGHT_GRAY, 0, NO_IMAGE, true);
+        keys.push_back(GetCommand(c)->GetKey());
       }
   }
 
   game::SetStandardListAttributes(List);
-  List.Draw();
+  List.AddFlags(SELECTABLE | DONT_SHOW_KEYS);
+  int res = List.Draw();
+  if(res >= 0 && res < keys.size()) {
+    bool HasActed = false, ValidKeyPressed = false;
+    Who->PerformPlayerCommand(keys[res], HasActed, ValidKeyPressed);
+    return HasActed;
+  }
+
   return false;
 }
 

--- a/Main/Source/command.cpp
+++ b/Main/Source/command.cpp
@@ -1082,7 +1082,7 @@ truth commandsystem::WhatToEngrave(character* Char,bool bEngraveMapNote,v2 v2Eng
   }
 
   int Key = 0;
-  while(!(Key == KEY_ESC || Key == ' '))
+  while(!(Key == KEY_ESC || Key == ' ' || Key == KEY_CONTROLLER_B))
   {
     if(!bEngraveMapNote)
       Key = game::AskForKeyPress(CONST_S("Do you want to (.) engrave a square, or inscribe an (i)tem? ['.' or 'i', ESC exits]"));
@@ -1127,7 +1127,7 @@ truth commandsystem::WhatToEngrave(character* Char,bool bEngraveMapNote,v2 v2Eng
       break;
     }
 
-    if(Key == '.')
+    if(Key == '.' || Key == KEY_CONTROLLER_A)
     {
       festring What;
 
@@ -1137,7 +1137,7 @@ truth commandsystem::WhatToEngrave(character* Char,bool bEngraveMapNote,v2 v2Eng
       break;
     }
 
-    if(Key == 'i')
+    if(Key == 'i' || Key == KEY_CONTROLLER_Y)
     {
       if(!Char->GetStack()->GetItems())
       {
@@ -1745,11 +1745,13 @@ truth commandsystem::Go(character* Char)
     v2RouteTarget=v2(0,0);
 
   if(!v2RouteTarget.Is0()){
-    switch(game::KeyQuestion(CONST_S("Continue going thru the route? [y/n]"), KEY_ESC, 2, 'y', 'n')){
+    switch(game::KeyQuestion(CONST_S("Continue going thru the route? [y/n]"), KEY_ESC, 4, 'y', 'n', KEY_CONTROLLER_A, KEY_CONTROLLER_B)){
       case 'y':
+      case KEY_CONTROLLER_A:
         Dir = YOURSELF;
         break;
       case 'n':
+      case KEY_CONTROLLER_B:
         v2RouteTarget=v2(0,0);
         break;
       default:

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -3015,6 +3015,17 @@ void game::DrawEverythingNoBlit(truth AnimationDraw)
         igraph::DrawCursor(ScreenCoord, Player->GetCursorData());
         if(!DoZoom())UpdatePosAroundForXBRZ(Pos);
       }
+
+      if(globalwindowhandler::ControllerEnabled())
+      {
+        auto Pos1 = Pos + globalwindowhandler::GetControllerDirection();
+        if(OnScreen(Pos1))
+        {
+          v2 ScreenCoord1 = CalculateScreenCoordinates(Pos1);
+          igraph::DrawCursor(ScreenCoord1, Player->GetCursorData());
+          if(!DoZoom())UpdatePosAroundForXBRZ(Pos1);
+        }
+      }
     }
     else
     {
@@ -3027,6 +3038,17 @@ void game::DrawEverythingNoBlit(truth AnimationDraw)
           v2 ScreenCoord = CalculateScreenCoordinates(Pos);
           igraph::DrawCursor(ScreenCoord, Player->GetCursorData()|CURSOR_BIG, c);
           if(!DoZoom())UpdatePosAroundForXBRZ(Pos);
+        }
+
+        if(globalwindowhandler::ControllerEnabled())
+        {
+          auto Pos1 = Pos + globalwindowhandler::GetControllerDirection();
+          if(OnScreen(Pos1))
+          {
+            v2 ScreenCoord1 = CalculateScreenCoordinates(Pos1);
+            igraph::DrawCursor(ScreenCoord1, Player->GetCursorData()|CURSOR_BIG);
+            if(!DoZoom())UpdatePosAroundForXBRZ(Pos1);
+          }
         }
       }
     }
@@ -3703,6 +3725,12 @@ v2 game::GetDirectionVectorForKey(int Key)
     if(Key == GetMoveCommandKey(c))
       return GetMoveVector(c);
 
+  if(Key >= KEY_CONTROLLER_DIRECTION + 1 && Key <= KEY_CONTROLLER_DIRECTION + 9)
+    {
+      int tmp = Key - KEY_CONTROLLER_DIRECTION - 1;
+      return v2((tmp % 3) - 1, (tmp / 3) - 1);
+    }
+
   return ERROR_V2;
 }
 
@@ -3759,6 +3787,14 @@ int game::DirectionQuestion(cfestring& Topic, truth RequireAnswer, truth AcceptY
     for(int c = 0; c < DIRECTION_COMMAND_KEYS; ++c)
       if(Key == GetMoveCommandKey(c))
         return c;
+
+    if(Key >= KEY_CONTROLLER_DIRECTION + 1 && Key <= KEY_CONTROLLER_DIRECTION + 9)
+      {
+        v2 Dir = GetDirectionVectorForKey(Key);
+        for(int c = 0; c < DIRECTION_COMMAND_KEYS; ++c)
+          if(GetMoveVector(c) == Dir)
+           return c;
+      }
 
     if(Key==keyChoseDefaultDir)
       return defaultDir;

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -1244,8 +1244,8 @@ truth game::TruthQuestion(cfestring& String, int DefaultAnswer, int OtherKeyForT
   else if(DefaultAnswer != REQUIRES_ANSWER)
     ABORT("Illegal TruthQuestion DefaultAnswer send!");
 
-  int FromKeyQuestion = KeyQuestion(String, DefaultAnswer, 5, 'y', 'Y', 'n', 'N', OtherKeyForTrue);
-  return FromKeyQuestion == 'y' || FromKeyQuestion == 'Y' || FromKeyQuestion == OtherKeyForTrue;
+  int FromKeyQuestion = KeyQuestion(String, DefaultAnswer, 8, 'y', 'Y', 'n', 'N', OtherKeyForTrue, KEY_CONTROLLER_A, KEY_CONTROLLER_B, KEY_CONTROLLER_Y);
+  return FromKeyQuestion == 'y' || FromKeyQuestion == 'Y' || FromKeyQuestion == OtherKeyForTrue || FromKeyQuestion == KEY_CONTROLLER_A;
 }
 
 void game::DrawEverything()
@@ -4314,13 +4314,13 @@ v2 game::PositionQuestion(cfestring& Topic, v2 CursorPos, void (*Handler)(v2),
     else
       GetCurrentArea()->GetSquare(CursorPos)->SendStrongNewDrawRequest();
 
-    if(Key == ' ' || Key == '.')
+    if(Key == ' ' || Key == '.' || Key == KEY_CONTROLLER_A)
     {
       Return = CursorPos;
       break;
     }
 
-    if(Key == KEY_ESC)
+    if(Key == KEY_ESC || Key == KEY_CONTROLLER_B)
     {
       Return = ERROR_V2;
       break;
@@ -4540,7 +4540,7 @@ v2 game::LookKeyHandler(v2 CursorPos, int Key)
 
   switch(Key)
   {
-   case 'i':
+   case 'i': case KEY_CONTROLLER_X:
     if(!IsInWilderness())
     {
       if(Square->CanBeSeenByPlayer() || CursorPos == Player->GetPosSafely() || GetSeeWholeMapCheatMode()){
@@ -4557,7 +4557,7 @@ v2 game::LookKeyHandler(v2 CursorPos, int Key)
     }
 
     break;
-   case 'c':
+   case 'c': case KEY_CONTROLLER_Y:
     if(Square->CanBeSeenByPlayer() || CursorPos == Player->GetPos() || GetSeeWholeMapCheatMode())
     {
       character* Char = Square->GetCharacter();

--- a/Main/Source/lterras.cpp
+++ b/Main/Source/lterras.cpp
@@ -1237,14 +1237,16 @@ truth olterraincontainer::Open(character* Opener)
 
   switch(game::KeyQuestion(CONST_S("Do you want to (t)ake something from or "
                                    "(p)ut something in this container? [t,p]"),
-                           KEY_ESC, 3, 't', 'p', KEY_ESC))
+                           KEY_ESC, 8, 't', 'p', 'T', 'P', KEY_CONTROLLER_A, KEY_CONTROLLER_Y, KEY_CONTROLLER_B, KEY_ESC))
   {
    case 't':
    case 'T':
+   case KEY_CONTROLLER_A:
     Success = GetContained()->TakeSomethingFrom(Opener, GetName(DEFINITE));
     break;
    case 'p':
    case 'P':
+   case KEY_CONTROLLER_Y:
     Success = GetContained()->PutSomethingIn(Opener, GetName(DEFINITE), GetStorageVolume(), 0);
     break;
    default:

--- a/Main/Source/miscitem.cpp
+++ b/Main/Source/miscitem.cpp
@@ -1388,14 +1388,16 @@ truth itemcontainer::Open(character* Opener)
                               "(p)ut something in this container? [t,p]");
   truth Success;
 
-  switch(game::KeyQuestion(Question, KEY_ESC, 3, 't', 'p', KEY_ESC))
+  switch(game::KeyQuestion(Question, KEY_ESC, 10, 't', 'p', 'T', 'P', KEY_ESC, KEY_CONTROLLER_A, KEY_CONTROLLER_Y, KEY_CONTROLLER_B))
   {
    case 't':
    case 'T':
+   case KEY_CONTROLLER_A:
     Success = GetContained()->TakeSomethingFrom(Opener, GetName(DEFINITE));
     break;
    case 'p':
    case 'P':
+   case KEY_CONTROLLER_Y:
     Success = GetContained()->PutSomethingIn(Opener, GetName(DEFINITE), GetStorageVolume(), GetID());
     break;
    default:


### PR DESCRIPTION
I have implemented some features to make IVAN easier to play on some modern devices.

* Diagonal directions can now be entered by pressing Left/Right together with Shift/Ctrl. This control scheme is used in some other roguelikes as a way to make the game easier to play on laptop keyboards that do not have numpad.
* The 'keyboard layout' command is now a selectable list. It is possible to launch a command directly by choosing it from there.
* Implemented basic controller support. Movement (and other directional input) is done by pushing the joystick in the desired direction and pressing Ⓐ (this seems to be the standard roguelike controller support). Pressing Ⓨ in the main command interface yields the keyboard layout screen. In lists, D-pad sends arrow keys, Ⓐ selects, Ⓑ cancels, Ⓧ/Ⓨ work like page up/down. Also the game reacts to controller input in some other questions.