### PR TITLE
Portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,11 @@ add_definitions(-DIVAN_VERSION="${PROJECT_VERSION}" -DUSE_SDL)
 option(BUILD_MAC_APP "Build standalone application for MacOS" OFF)
 option(USE_HOME_FOR_STATE_DIR "Statedir will be /.ivan/ in current user's homedir" OFF)
 option(WIZARD "Enable Wizard Mode" OFF)
+option(PORTABLE_BUILD "Keep game and user data in the directory IVAN is launched from" OFF)
 
 if(UNIX)
   add_definitions(-DUNIX)
+  if(NOT PORTABLE_BUILD)
   include(GNUInstallDirs)
 
   if(BUILD_MAC_APP)
@@ -36,6 +38,7 @@ if(UNIX)
               "If you have game data in \"${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/ivan\","
               " please move them to \"$ENV{HOME}/.ivan\".")
     endif()
+  endif()
   endif()
 
 elseif(WIN32)
@@ -61,6 +64,10 @@ endif()
 
 if(WIZARD)
   add_definitions(-DWIZARD)
+endif()
+
+if(PORTABLE_BUILD)
+  add_definitions(-DPORTABLE_BUILD)
 endif()
 
 find_path(EXECINFO_INCLUDE_DIR NAMES execinfo.h)

--- a/FeLib/Include/fearray.h
+++ b/FeLib/Include/fearray.h
@@ -45,9 +45,9 @@ template <class type>
 inline fearray<type>::fearray(const type* Array, sizetype Size)
 : Size(Size)
 {
-  char* Ptr = new char[Size * sizeof(type) + sizeof(int*)];
+  char* Ptr = new char[Size * sizeof(type) + sizeof(ulong)];
   *reinterpret_cast<ulong*>(Ptr) = 0;
-  Data = reinterpret_cast<type*>(Ptr + sizeof(int*));
+  Data = reinterpret_cast<type*>(Ptr + sizeof(ulong));
 
   for(sizetype c = 0; c < Size; ++c)
     new(&Data[c]) type(Array[c]);

--- a/FeLib/Include/hscore.h
+++ b/FeLib/Include/hscore.h
@@ -18,12 +18,17 @@
 
 #include "festring.h"
 
+#ifdef PORTABLE_BUILD
+#define HIGH_SCORE_FILENAME "ivan-highscore.scores"
+#else
+
 #ifdef UNIX
 #define HIGH_SCORE_FILENAME "ivan-highscore.scores"
 #endif
 
 #if defined(WIN32) || defined(__DJGPP__)
 #define HIGH_SCORE_FILENAME "HScore.dat"
+#endif
 #endif
 
 class festring;

--- a/FeLib/Include/save.h
+++ b/FeLib/Include/save.h
@@ -229,8 +229,41 @@ inline inputfile& operator>>(inputfile& SaveFile, ushort& Value)
   return SaveFile;
 }
 
+/* SAVE_COMPATIBILITY:
+ * make x86_64-w64-mingw32 saves compatible with Linux,
+ * by forcing the correct sizes.
+ * Note: This also lets us save 64-bit time_t values.
+ **/
+
+#if SAVE_COMPATIBILITY
+#include <stdint.h>
+RAW_SAVE_LOAD(int64_t)
+RAW_SAVE_LOAD(uint64_t)
+
+inline outputfile& operator<<(outputfile& SaveFile, long Value)
+{
+  int64_t Value2 = Value; return SaveFile << Value2;
+}
+
+inline inputfile& operator>>(inputfile& SaveFile, long& Value)
+{
+  int64_t Value2; SaveFile >> Value2; Value = Value2; return SaveFile;
+}
+
+inline outputfile& operator<<(outputfile& SaveFile, ulong Value)
+{
+  uint64_t Value2 = Value; return SaveFile << Value2;
+}
+
+inline inputfile& operator>>(inputfile& SaveFile, ulong& Value)
+{
+  uint64_t Value2; SaveFile >> Value2; Value = Value2; return SaveFile;
+}
+
+#else
 RAW_SAVE_LOAD(long)
 RAW_SAVE_LOAD(ulong)
+#endif
 RAW_SAVE_LOAD(int)
 RAW_SAVE_LOAD(uint)
 RAW_SAVE_LOAD(double)

--- a/FeLib/Source/feio.cpp
+++ b/FeLib/Source/feio.cpp
@@ -1061,7 +1061,7 @@ festring iosystem::ContinueMenu(col16 TopicColor, col16 ListColor,
       closedir(dp);
     }
   }
-#endif
+#else
 
 #ifdef WIN32
   struct _finddata_t Found;

--- a/FeLib/Source/feio.cpp
+++ b/FeLib/Source/feio.cpp
@@ -22,13 +22,22 @@
 #include <cstring>
 #include <vector>
 
+#if defined(UNIX) || defined(USE_OPENDIR)
+#include <dirent.h>
+#else
+
 #ifdef WIN32
 #define stat _stat
 #include <io.h>
 #endif
 
+#ifdef __DJGPP__
+#include <dir.h>
+#endif
+
+#endif
+
 #ifdef UNIX
-#include <dirent.h>
 #include <stddef.h>
 #include <cstdio>
 #include <time.h>
@@ -37,9 +46,6 @@
 #include <sstream>
 #endif
 
-#ifdef __DJGPP__
-#include <dir.h>
-#endif
 
 #include "bitmap.h"
 #include "error.h"
@@ -1044,7 +1050,7 @@ festring iosystem::ContinueMenu(col16 TopicColor, col16 ListColor,
   felist List(CONST_S("Choose a file and be sorry:"), TopicColor);
 
   ////////////////////////// OS SPECIFIC!!! collect all files at save folder. //////////////////////////
-#ifdef UNIX
+#if defined(UNIX) || defined(USE_OPENDIR)
   {
     DIR* dp;
     struct dirent* ep;
@@ -1091,6 +1097,7 @@ festring iosystem::ContinueMenu(col16 TopicColor, col16 ListColor,
       Check = findnext(&Found);
     }
   }
+#endif
 #endif
 
   if(vFiles.size()==0){

--- a/FeLib/Source/femath.cpp
+++ b/FeLib/Source/femath.cpp
@@ -315,26 +315,22 @@ void ReadData(region& R, inputfile& SaveFile)
 
 outputfile& operator<<(outputfile& SaveFile, const interval& I)
 {
-  SaveFile.Write(reinterpret_cast<cchar*>(&I), sizeof(I));
-  return SaveFile;
+  return SaveFile << I.Min << I.Max;
 }
 
 inputfile& operator>>(inputfile& SaveFile, interval& I)
 {
-  SaveFile.Read(reinterpret_cast<char*>(&I), sizeof(I));
-  return SaveFile;
+  return SaveFile >> I.Min >> I.Max;
 }
 
 outputfile& operator<<(outputfile& SaveFile, const region& R)
 {
-  SaveFile.Write(reinterpret_cast<cchar*>(&R), sizeof(R));
-  return SaveFile;
+  return SaveFile << R.X << R.Y;
 }
 
 inputfile& operator>>(inputfile& SaveFile, region& R)
 {
-  SaveFile.Read(reinterpret_cast<char*>(&R), sizeof(R));
-  return SaveFile;
+  return SaveFile >> R.X >> R.Y;
 }
 
 long femath::SumArray(const fearray<long>& Vector)

--- a/FeLib/Source/festring.cpp
+++ b/FeLib/Source/festring.cpp
@@ -884,7 +884,7 @@ long festring::GetCheckSum() const
 void festring::CreateNewData(sizetype N)
 {
   Reserved = N|FESTRING_PAGE;
-  Data = sizeof(int*) + new char[Reserved + sizeof(int*) + 1];
+  Data = sizeof(ulong) + new char[Reserved + sizeof(ulong) + 1];
   OwnsData = true;
   REFS(Data) = 0;
   Size = 0;

--- a/FeLib/Source/save.cpp
+++ b/FeLib/Source/save.cpp
@@ -811,6 +811,9 @@ void MakePath(cfestring& Path)
 
 festring GetUserDataDir()
 {
+#ifdef PORTABLE_BUILD
+  return "./";
+#else
 #ifdef UNIX
   festring Dir;
 #ifdef MAC_APP
@@ -833,5 +836,6 @@ festring GetUserDataDir()
 
 #if defined(WIN32) || defined(__DJGPP__)
   return "./";
+#endif
 #endif
 }

--- a/Main/Include/square.h
+++ b/Main/Include/square.h
@@ -39,7 +39,7 @@ class square
   area* GetArea() const { return AreaUnder; }
   virtual gterrain* GetGTerrain() const = 0;
   virtual oterrain* GetOTerrain() const = 0;
-  festring GetMemorizedDescription() { return MemorizedDescription; }
+  festring GetMemorizedDescription() const { return MemorizedDescription; }
   void SetMemorizedDescription(cfestring& What) { MemorizedDescription = What; }
   virtual truth CanBeSeenByPlayer(truth = false) const = 0;
   virtual truth CanBeSeenFrom(v2, long, truth = false) const = 0;

--- a/Main/Include/trap.h
+++ b/Main/Include/trap.h
@@ -47,6 +47,7 @@ class itemtrapbase
 {
  public:
   itemtrapbase() : Active(false) { }
+  virtual ~itemtrapbase() { }
   void Save(outputfile&) const;
   void Load(inputfile&);
   void SetIsActive(truth);

--- a/Main/Source/bugworkaround.cpp
+++ b/Main/Source/bugworkaround.cpp
@@ -428,7 +428,7 @@ character* bugfixdp::ValidatePlayerAt(square* sqr)
 
   if(vPF.size()>1){ // FIRST CHECK/FIX!
     festring fsMsg;
-    fsMsg << "Multiple player instances found (x" << vPF.size() << "), try to fix this?";
+    fsMsg << "Multiple player instances found (x" << int(vPF.size()) << "), try to fix this?";
     if(AlertConfirmFixMsg(fsMsg.CStr()))
       return BugWorkaroundDupPlayer();
     /**

--- a/Main/Source/cmdcraft.cpp
+++ b/Main/Source/cmdcraft.cpp
@@ -3062,7 +3062,7 @@ void updateCraftDesc(){
 
   festring fsDesc=fsSkill;
   if(vSuspended.size()>0)
-    fsDesc<<" (Suspended Actions: "<<vSuspended.size()<<")";
+    fsDesc<<" (Suspended Actions: "<<int(vSuspended.size())<<")";
 
   craftRecipes.AddDescription(fsDesc,fSkill<10?RED:WHITE);
 }

--- a/Main/Source/game.cpp
+++ b/Main/Source/game.cpp
@@ -5304,6 +5304,9 @@ inputfile& operator>>(inputfile& SaveFile, dangerid& Value)
 
 festring game::GetDataDir()
 {
+#ifdef PORTABLE_BUILD
+  return "./";
+#else
 #ifdef UNIX
 #ifdef MAC_APP
   return "../Resources/data/";
@@ -5314,6 +5317,7 @@ festring game::GetDataDir()
 
 #if defined(WIN32) || defined(__DJGPP__)
   return GetUserDataDir();
+#endif
 #endif
 }
 

--- a/Main/Source/lsquare.cpp
+++ b/Main/Source/lsquare.cpp
@@ -1398,14 +1398,12 @@ void lsquare::KickAnyoneStandingHereAway()
 
 outputfile& operator<<(outputfile& SaveFile, const emitter& Emitter)
 {
-  SaveFile.Write(reinterpret_cast<cchar*>(&Emitter), sizeof(Emitter));
-  return SaveFile;
+  return SaveFile << Emitter.ID << Emitter.Emitation;
 }
 
 inputfile& operator>>(inputfile& SaveFile, emitter& Emitter)
 {
-  SaveFile.Read(reinterpret_cast<char*>(&Emitter), sizeof(Emitter));
-  return SaveFile;
+  return SaveFile >> Emitter.ID >> Emitter.Emitation;
 }
 
 void lsquare::AddItem(item* Item)

--- a/xbrzscale/libxbrzscale.h
+++ b/xbrzscale/libxbrzscale.h
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _XRBZSCALE_
+#define _XRBZSCALE_
+
 #ifndef XBRZLIB_RELATIVEPATHSDL
 #include <SDL_stdinc.h>
 #else
@@ -49,3 +52,4 @@ class libxbrzscale
   static bool bFreeInputSurfaceAfterScale;
   static bool bFreeOutputSurfaceAfterScale;
 };
+#endif

--- a/xbrzscale/libxbrzscale.h
+++ b/xbrzscale/libxbrzscale.h
@@ -17,7 +17,7 @@
  */
 
 #ifndef _XRBZSCALE_
-#define _XRBZSCALE_
+#define _XBRZSCALE_
 
 #ifndef XBRZLIB_RELATIVEPATHSDL
 #include <SDL_stdinc.h>

--- a/xbrzscale/libxbrzscale.h
+++ b/xbrzscale/libxbrzscale.h
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _XRBZSCALE_
+#ifndef _XBRZSCALE_
 #define _XBRZSCALE_
 
 #ifndef XBRZLIB_RELATIVEPATHSDL


### PR DESCRIPTION
Various commits intended to improve portability, in various ways.

Note: I am cross-compiling the Windows version on Linux using `x86_64-w64-mingw32-g++`. So this is 64-bit. I am not sure how to make `cmake` work (I am compiling using my own scripts instead which I have not included in the PR).

* The saves in the Linux and Windows versions I compiled were not compatible, because on Linux "long" is 64-bit, while in Windows, at least according to the x86_64-w64-mingw32-g++ compiler, it is 32-bit, so Windows would read 32 bit of a Linux long and the next 32 bits would be assumed to refer to something else. I have fixed this by making save.h use 64 bits anyway when recording "long" or "ulong". An alternative solution would be redefine "ulong" to be 64-bit and replace all occurrences of "long" with a new 64-bit type.
* The Linux version was configured to install itself in the system -- added a cmake option PORTABLE_BUILD to create a "portable build" working from a single directory. Also this option uniformizes the highscore filename between Linux and Windows. It was mostly for Steam but I guess it could also be used if you wanted to launch IVAN from a USB stick that you use on both Linux and Windows, and keep user data between them.
* There was a problem with `festring` and `fearray` allocating an `int*` before the actual content and then treating it as `ulong`, which did not work when `int*` and `ulong` have different sizes. (Weird that this worked on Wine for me. It crashed on actual Windows though.)
* Also it appears that `_findfist` crashes in w64-mingw32 (even in my minimal program) -- I have added an option `USE_OPENDIR` to use the Unix standard functions `opendir`/`readdir` which work there.